### PR TITLE
docs: release requirements, command fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ jq '.
 ' .vscode/settings.json > .vscode/settings.tmp && mv .vscode/settings.tmp .vscode/settings.json
 ```
 
-
 Optionally, enable these settings across all projects:
 - Linux: `~/.config/Code/User/settings.json`
 - macOS: `~/Library/Application Support/Code/User/settings.json`
@@ -74,6 +73,18 @@ To stop using upstream config simply delete `.github/copilot-upstream.md` and co
 1. For most projects, the default setup works well out of the box
 2. Put your changes in `.github/copilot-instructions.md`
 3. Recommend upstream changes at https://github.com/bcgov/copilot-instructions
+
+## Release Process for Upstream Maintainers
+
+To ensure downstream repositories receive automatic updates via Renovate:
+
+1. **When creating a new release, copy the entire contents of `.github/copilot-upstream.md` and paste it as the release notes body.**
+    - Do **not** add extra headings or text—only the raw Markdown content of the file.
+    - This allows Renovate to propagate the latest guidelines to all subscribed downstream repositories.
+2. **Publish the release as usual.**
+
+> **Note:**
+> Downstream repositories will receive a Renovate PR that fully replaces their `.github/copilot-upstream.md` file with the content from your release notes.
 
 ## Additional Resources
 


### PR DESCRIPTION
Fix commands for setting up default files.  Add programmatic steps for configuring settings.json.  Explain release body needing to match the contents of copilot-upstream.md.  (this will be handled by a workflow soon)