### PR TITLE
docs(assistant): add AI assistant guardrails and tighten git workflow guidance

### DIFF
--- a/.github/copilot-upstream.md
+++ b/.github/copilot-upstream.md
@@ -58,7 +58,7 @@ git status                    # Confirm on feature branch
 
 **NEVER create branches without first:**
 - Confirming current branch is main
-- Confirming main is up to date  
+- Confirming main is up to date
 - Confirming no uncommitted changes
 ```
 ```
@@ -133,7 +133,7 @@ git log --oneline main..HEAD  # Show PR contents
 
 **If ANY problems, fix them FIRST before declaring ready**
 
-### Cursor operational guardrails (org-wide)
+### AI assistant operational guardrails (org-wide)
 
 - Confirm before any write to external repos; show exact commands.
 - Avoid chained one-liners; use short, atomic steps; stop on first error.
@@ -142,7 +142,7 @@ git log --oneline main..HEAD  # Show PR contents
 - No auto-merge or force-push without explicit approval.
 - Conventional commits; include full git command sequences in discussions.
 - Never use local .env files.
-- Canonical parameters file: `/home/derek/Documents/1-Personal/Linux/cursorrules` (treated as authoritative).
+- Canonical parameters file (local): `/home/derek/Documents/1-Personal/Linux/cursorrules`.
 
 ### Renovate testing protocol
 

--- a/.github/copilot-upstream.md
+++ b/.github/copilot-upstream.md
@@ -133,9 +133,9 @@ git log --oneline main..HEAD  # Show PR contents
 
 **If ANY problems, fix them FIRST before declaring ready**
 
-### AI assistant operational guardrails (org-wide)
+### AI assistant operational guardrails
 
-These guardrails are tool-agnostic and apply across AI coding assistants used at work. Personal or workstation-specific rules should live in a local parameters file; see the canonical path below.
+These guardrails are tool-agnostic and apply across AI coding assistants used in projects. Personal or workstation-specific rules should live in a local parameters file; see the canonical path below.
 
 - Confirm before any write to external repos; show exact commands.
 - Avoid chained one-liners; use short, atomic steps; stop on first error.

--- a/.github/copilot-upstream.md
+++ b/.github/copilot-upstream.md
@@ -146,15 +146,4 @@ These guardrails are tool-agnostic and apply across AI coding assistants used in
 - Never use local .env files.
 - Canonical parameters file (local): `/home/derek/Documents/1-Personal/Linux/cursorrules`.
 
-### Renovate testing protocol
-
-- Use `renovate-config-validator` before committing; test upstream presets via `github>bcgov/renovate-config:default.json#test/regex-managers-migration`. For commands and full guidance, see Appendix A.
-
-## Appendix A: Renovate testing protocol details
-
-- Validate locally before any commit:
-  - `npx --yes -p renovate renovate-config-validator renovate.json`
-- When testing upstream presets:
-  - Use explicit file+branch: `github>bcgov/renovate-config:default.json#test/regex-managers-migration`
-  - After test, revert to `#v1` or pin a commit SHA for stability.
-- Avoid per-repo churn across many repos; prefer upstream preset changes to drive migrations.
+<!-- Project-specific Renovate testing guidance should live in each repo's `.github/copilot-instructions.md`. -->

--- a/.github/copilot-upstream.md
+++ b/.github/copilot-upstream.md
@@ -132,3 +132,23 @@ git log --oneline main..HEAD  # Show PR contents
 ```
 
 **If ANY problems, fix them FIRST before declaring ready**
+
+### Cursor operational guardrails (org-wide)
+
+- Confirm before any write to external repos; show exact commands.
+- Avoid chained one-liners; use short, atomic steps; stop on first error.
+- Shell defaults during edit sessions: `set -e` only (no `-u`/`pipefail`).
+- Use `printf`/`cat` + temp files for content; validate JSON with `jq` before commit.
+- No auto-merge or force-push without explicit approval.
+- Conventional commits; include full git command sequences in discussions.
+- Never use local .env files.
+- Canonical parameters file: `/home/derek/Documents/1-Personal/Linux/cursorrules` (treated as authoritative).
+
+### Renovate testing protocol
+
+- Local validation before any commit:
+  - `npx --yes -p renovate renovate-config-validator renovate.json`
+- When testing upstream presets:
+  - Use explicit file+branch: `github>bcgov/renovate-config:default.json#test/regex-managers-migration`
+  - After test, revert to `#v1` or pin a commit SHA.
+- No per-repo fixes across 80+ repos; rely on upstream preset changes to migrate downstream.

--- a/.github/copilot-upstream.md
+++ b/.github/copilot-upstream.md
@@ -146,9 +146,13 @@ git log --oneline main..HEAD  # Show PR contents
 
 ### Renovate testing protocol
 
-- Local validation before any commit:
+- Use `renovate-config-validator` before committing; test upstream presets via `github>bcgov/renovate-config:default.json#test/regex-managers-migration`. For commands and full guidance, see Appendix A.
+
+## Appendix A: Renovate testing protocol details
+
+- Validate locally before any commit:
   - `npx --yes -p renovate renovate-config-validator renovate.json`
 - When testing upstream presets:
   - Use explicit file+branch: `github>bcgov/renovate-config:default.json#test/regex-managers-migration`
-  - After test, revert to `#v1` or pin a commit SHA.
-- No per-repo fixes across 80+ repos; rely on upstream preset changes to migrate downstream.
+  - After test, revert to `#v1` or pin a commit SHA for stability.
+- Avoid per-repo churn across many repos; prefer upstream preset changes to drive migrations.

--- a/.github/copilot-upstream.md
+++ b/.github/copilot-upstream.md
@@ -135,6 +135,8 @@ git log --oneline main..HEAD  # Show PR contents
 
 ### AI assistant operational guardrails (org-wide)
 
+These guardrails are tool-agnostic and apply across AI coding assistants used at work. Personal or workstation-specific rules should live in a local parameters file; see the canonical path below.
+
 - Confirm before any write to external repos; show exact commands.
 - Avoid chained one-liners; use short, atomic steps; stop on first error.
 - Shell defaults during edit sessions: `set -e` only (no `-u`/`pipefail`).

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ As AI coding assistants become more common in government development, protecting
 
 ### The Problem
 
-AI coding assistants (GitHub Copilot, Cursor, etc.) operate with your credentials and can:
+AI coding assistants (GitHub Copilot and similar tools) operate with your credentials and can:
 - **Push directly to main branches** (bypassing PR requirements)
 - **Force push** to any branch (potentially losing work)
 - **Delete branches** without understanding the consequences
@@ -311,7 +311,7 @@ command git push origin main
 
 #### When to Use
 
-- **AI coding assistants** (GitHub Copilot, Cursor, etc.)
+- **AI coding assistants** (GitHub Copilot and similar tools)
 - **Large repository portfolios** (50+ repos)
 - **Cross-organizational development** (BCGov, multiple teams)
 - **DevOps automation** (scripts, CI/CD, etc.)


### PR DESCRIPTION
This PR adds concise AI assistant guardrails and tightens git workflow guidance in the upstream instructions.

Scope
- Add AI assistant operational guardrails (tool-agnostic)
- Clarify project-level applicability (avoid org-wide language)
- Make README wording vendor-neutral (tool-agnostic)
- Remove Renovate testing protocol from upstream; project-specific items belong in per-repo guidance

Notes
- Documentation-only changes; no functional code changes
- Conventional commits used for commit messages
