### PR TITLE
feat: improve git safety script parameter parsing and add auth status

### DIFF
--- a/scripts/git-safety.sh
+++ b/scripts/git-safety.sh
@@ -103,7 +103,7 @@ gh() {
     if [[ "$is_allowed" == true ]]; then
         $(command which gh) "$@"
     else
-	    echo "🚨 BLOCKED: 'gh $*' not in allowlist! Use GitHub UI for management."
+        echo "🚨 BLOCKED: 'gh $*' not in allowlist! Use GitHub UI for management."
         return 1
     fi
 }


### PR DESCRIPTION
## Summary

Improves the git safety script with better parameter parsing and adds auth status command to allowlist.

## Changes

- **Limit parameter parsing**: Only parse first two parameters to avoid issues with complex commands
- **Add auth status**: Allow `gh auth status` command for debugging authentication
- **Better command matching**: More robust allowlist matching that handles complex arguments

## Commits

- `6e11896`: Limit git safety checks to the first two params
- `0ee90e1`: feat: add auth status to gh allowlist

## Testing

- Verified `gh auth status` now works instead of being blocked
- Confirmed `gh pr create` still works with complex parameters
- Safety script maintains security while improving usability