### PR TITLE
fix: allow git clone in safety script

### DIFF
--- a/scripts/git-safety.sh
+++ b/scripts/git-safety.sh
@@ -17,7 +17,7 @@ git() {
 
     if [[ "$current_branch" = "$default_branch" ]]; then
         local first_cmd=$(echo "$args" | awk '{print $1}')
-        local allowed_commands="branch checkout config diff fetch help log pull restore show status switch version"
+        local allowed_commands="branch checkout clone config diff fetch help log pull restore show status switch version"
 
         if [[ " $allowed_commands " != *" $first_cmd "* ]]; then
             echo "🚨 BLOCKED: '$first_cmd' not allowed on default branch ($default_branch)! Use feature branches."


### PR DESCRIPTION
## Problem
The git-safety.sh script was blocking `git clone` operations, preventing users from cloning repositories.

## Solution
Added 'clone' to the allowed commands list in git-safety.sh. The `git clone` command is safe as it creates new repositories without modifying existing ones.

## Changes
- Added 'clone' to allowed_commands in git-safety.sh
- Resolves blocking of git clone operations

## Testing
- Confirmed git clone now works without being blocked by safety script