### PR TITLE
docs: reorganize and strengthen copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,7 +27,7 @@ You are a full stack developer for BC Government projects. Follow these instruct
 - **Formatting:** Use 4-space indent, no trailing whitespace, LF line endings.
 - **Development:** Verify the app works first. Keep changes small, focused, and on the latest stable versions.
 - **Package Management (npm):** NEVER use `--legacy-peer-deps`, edit lock files, or silently downgrade. Resolve conflicts by updating to compatible versions. If unsolvable, ask the user.
-- **Least Privilege (CRITICAL):** ALWAYS use minimum permissions. GitHub Actions: `permissions: {}` at workflow level. Containers: non-root. Cloud/DB/APIs: minimal scopes.
+- **Least Privilege (CRITICAL):** ALWAYS use minimum permissions. GitHub Actions: `permissions: {}` at workflow level, explicit at job/step. Containers: non-root, drop capabilities. Cloud/DB/APIs: minimal scopes.
 - **Iterative Simplification:** ALWAYS simplify after implementing: minimize code, question every conditional, remove unnecessary detection.
 - **Documentation:** MUST use 4-space indent in code blocks. MUST use GitHub Releases for version history. NEVER add manual tracking artifacts when GitHub features suffice. MUST only link to verified resources.
 


### PR DESCRIPTION
## Summary

Reorganize and strengthen `.github/copilot-instructions.md` for better AI consumption.

### Changes

- Restructure into clear sections: Scope, Hard Stops, Git Workflow, Standards, AI Guardrails
- Use strong directives throughout: NEVER for prohibitions, MUST for procedures, ALWAYS for principles
- Deduplicate rules (force-push, merge, git status) — each rule lives in one place
- Remove low-value directives (repo-as-database, `set -e`, `printf`/`jq` shell details)
- Cut expertise résumé from Scope, trim verbose workflow steps
- Merge Documentation Rules into Standards
- Add Hard Stops: "NEVER push directly to main" (standalone), "NEVER merge PRs; ALWAYS leave merging to humans"
- Add AI Guardrail: "Do not mark work complete until PR is created and link is provided"
- Strengthen Iterative Simplification to ALWAYS directive
- Net reduction from ~3400 to ~2800 characters