### PR TITLE
feat: stronger wording, fix PR creation ambiguity

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -69,14 +69,14 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 ### Operational Guardrails
 
 - ALWAYS push and open PRs to feature branches without asking permission
-- Do not mark work complete until PR is created and link is provided
-- Stop on first error; chain related commands with &&, separate unrelated ones
+- NEVER mark work complete until PR is created and link is provided
+- ALWAYS stop on first error; chain related commands with &&, separate unrelated ones
 
 ### Git Workflow (Ordered Checklist)
 
 1. **Create Feature Branch (CRITICAL):** MUST be on `main` with clean tree, then `git pull && git switch -c feat/description`.
-2. **Create PR:** MUST confirm clean tree, `git fetch origin && git rebase main`, then `git push --set-upstream origin $(git branch --show-current)`. Use `gh pr create --title "feat: title" --body $'## Summary\n\nDescription'`.
-3. **Before Declaring PR Ready:** MUST confirm clean tree, on feature branch, review `git log --oneline main..HEAD`, then fix problems.
+2. **Create PR:** `git fetch origin && git rebase main`, then `git push --set-upstream origin $(git branch --show-current)`. MUST use `gh pr create --title "feat: title" --body $'## Summary\n\nDescription'`.
+3. **Before Declaring PR Ready:** Review `git log --oneline main..HEAD`, fix problems, verify clean tree before pushing.
 
 ### Project Standards
 


### PR DESCRIPTION
## Summary

Improve clarity and consistency of AI push/PR workflow rules and move active correction feedback to shared guidelines:

- **Feature branch freedom:** ALWAYS push and open PRs to feature branches without asking permission
- **Main protection:** Separate and strengthen hard stops (NEVER push to main or merge)
- **Wording consistency:** Use ALWAYS/NEVER throughout Operational Guardrails for uniform voice
- **Remove redundancy:** Eliminate duplicate main protection language from guardrails
- **Consolidate workflow:** Simplify git checklist redundancy (multiple 'confirm clean tree' checks)
- **Mandatory PRs:** Make `gh pr create` mandatory (not optional)
- **Active correction:** Add as core behavioral guideline for all AI assistants (moved from personal rules)

Main branches remain protected—only humans may merge.