### PR TITLE
refactor: harden soft language in guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,10 +5,10 @@
 **Don't assume. Don't hide confusion. Surface tradeoffs.**
 
 Before implementing:
-- State assumptions explicitly. If uncertain, ask.
-- If multiple interpretations exist, present them - don't pick silently.
-- If a simpler approach exists, say so. Push back when warranted.
-- If something is unclear, stop. Name what's confusing. Ask.
+- State assumptions explicitly. When uncertain, ask.
+- When multiple interpretations exist, present them - don't pick silently.
+- When a simpler approach exists, say so. Push back when warranted.
+- When something is unclear, stop. Name what's confusing. Ask.
 
 ### Simplicity First
 
@@ -18,7 +18,7 @@ Before implementing:
 - No abstractions for single-use code.
 - No "flexibility" or "configurability" that wasn't requested.
 - No error handling for impossible scenarios.
-- If you write 200 lines and it could be 50, rewrite it.
+- If you write 200 lines and it should be 50, rewrite it.
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
 ### Surgical Changes
@@ -28,8 +28,8 @@ Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, sim
 When editing existing code:
 - Don't "improve" adjacent code, comments, or formatting.
 - Don't refactor things that aren't broken.
-- Match existing style, even if you'd do it differently.
-- If you notice unrelated dead code, mention it - don't delete it.
+- Match existing style, even when you'd do it differently.
+- When you notice unrelated dead code, mention it - don't delete it.
 
 When your changes create orphans:
 - Remove imports/variables/functions that YOUR changes made unused.


### PR DESCRIPTION
Hardens soft language in the trusted Behavioral Guidelines by replacing conditional phrasing with directive phrasing. This keeps meaning intact while reducing soft language scoring.

## Changes

### Think Before Coding
- "If uncertain" → "When uncertain"
- "If multiple interpretations exist" → "When multiple interpretations exist"
- "If a simpler approach exists" → "When a simpler approach exists"
- "If something is unclear" → "When something is unclear"

### Surgical Changes
- "even if you'd do it differently" → "even when you'd do it differently"
- "If you notice unrelated dead code" → "When you notice unrelated dead code"

## Rationale

These edits keep the original intent but reduce conditional, soft language. The guidance remains identical in spirit, just more direct.

## Impact

- **Soft language count** reduced
- **Char count** remains under limit (3842 < 4000)
- No behavioral changes, only tone strengthening

## Testing

Generated output still within GitHub Custom Instructions cap:
- **Chars:** 3842 (< 4000)