### PR TITLE
feat: block silencing tooling warnings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@
 - NEVER commit credentials/secrets (.env files, API keys, tokens) OR include them in PR bodies/issues/markdown.
 - NEVER bypass security standards or grant broad permissions
 - NEVER silently delete, skip, or comment out failing tests, and NEVER advise ignoring or bypassing them. ALWAYS ensure all tests pass — fix the underlying code, not the test. If a test is genuinely outdated, flag it for human review before removing.
-- NEVER silence tooling warnings (ignoreDeprecations, eslint-disable, @ts-ignore, @ts-expect-error). Fix the root cause.
+- NEVER silence tooling diagnostics (`ignoreDeprecations`, `eslint-disable`, `@ts-ignore`, `@ts-expect-error`). Fix the root cause.
 
 ### Operational Guardrails
 - ALWAYS push and open PRs to feature branches without asking

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,6 +38,7 @@
 - NEVER commit credentials/secrets (.env files, API keys, tokens) OR include them in PR bodies/issues/markdown.
 - NEVER bypass security standards or grant broad permissions
 - NEVER silently delete, skip, or comment out failing tests, and NEVER advise ignoring or bypassing them. ALWAYS ensure all tests pass — fix the underlying code, not the test. If a test is genuinely outdated, flag it for human review before removing.
+- NEVER silence tooling warnings (ignoreDeprecations, eslint-disable, @ts-ignore, @ts-expect-error). Fix the root cause.
 
 ### Operational Guardrails
 - ALWAYS push and open PRs to feature branches without asking


### PR DESCRIPTION
## Summary

- Add rule preventing agents from silencing tooling warnings with `ignoreDeprecations`, `eslint-disable`, `@ts-ignore`, or `@ts-expect-error`. Agents must fix the root cause instead.

## Motivation

Agents were adding `ignoreDeprecations` to tsconfig to suppress deprecation warnings rather than fixing the underlying issue. This obscures problems, hides technical debt, and reduces build reliability.