### PR TITLE
feat: skills

### DIFF
--- a/.github/skills/autonomous-worktree/SKILL.md
+++ b/.github/skills/autonomous-worktree/SKILL.md
@@ -1,0 +1,49 @@
+# Autonomous Worktree Skill
+
+Use this skill when tasked with work on a GitHub Issue. It ensures a clean, isolated environment using `git worktree`, allowing you to work on multiple issues in parallel without workspace contamination.
+
+## Objective
+Automatically set up a dedicated `git worktree`, implement the requested fix, submit a PR with correct closure language, and clean up the environment.
+
+## The Standard Protocol
+
+### 1. Verification & Selection
+- Identify the Issue ID (e.g., #123).
+- Verify the base branch exists (usually `main`).
+
+### 2. Workspace Setup
+- Create a dedicated worktree:
+  ```bash
+  export ISSUE_ID="<id>"
+  git worktree add .workspaces/$ISSUE_ID -b fix/$ISSUE_ID main
+  ```
+- All subsequent operations MUST be performed inside `.workspaces/$ISSUE_ID`.
+
+### 3. Implementation Ritual
+- **Step 1: Test Baseline.** Run existing tests if they exist to confirm the current state.
+- **Step 2: Surgical Edit.** Apply changes following the "Surgical Changes" rule in `copilot-instructions.md`.
+- **Step 3: Verification.** Run tests to confirm the fix works and no regressions were introduced.
+
+### 4. The Pull Request
+- Stage and commit following **Conventional Commits** (e.g., `fix: resolve issue #123`).
+- Push the branch: `git push -u origin fix/$ISSUE_ID`.
+- Create the PR:
+  ```bash
+  gh pr create --title "fix: resolution for #$ISSUE_ID" --body "## Summary\n\n[Description of changes]\n\nCloses #$ISSUE_ID"
+  ```
+
+### 5. Cleanup (Post-Verification)
+- DO NOT automatically remove the worktree unless the user explicitly confirms the PR looks good.
+- Keep the workspace available for the user to inspect or for further refinements.
+- Once confirmed by the user, remove the worktree:
+  ```bash
+  git worktree remove .workspaces/$ISSUE_ID --force
+  git worktree prune
+  ```
+
+## Instructions for the AI
+When using this skill:
+- **ALWAYS** check for an existing `.workspaces/` folder to avoid conflicts.
+- **ALWAYS** use the correct closure keywords ("Closes", "Fixes", or "Resolves").
+- **PERSISTENCE**: DO NOT execute Step 5 (Cleanup) unless the user explicitly says "Cleanup the worktree" or "Delete the workspace" after the PR is created.
+- **AUTONOMY**: If `// turbo` is enabled, execute the setup and implementation steps without asking, but respect the **PERSISTENCE** rule for cleanup.

--- a/.github/skills/issue-worktree/SKILL.md
+++ b/.github/skills/issue-worktree/SKILL.md
@@ -1,9 +1,9 @@
-# Autonomous Worktree Skill
+# Issue Worktree Skill
 
-Use this skill when tasked with work on a GitHub Issue. It ensures a clean, isolated environment using `git worktree`, allowing you to work on multiple issues in parallel without workspace contamination.
+Use this skill when asked to work on a GitHub issue in an isolated worktree. It uses `git worktree` to keep issue work separate from your main checkout and supports a clean issue-to-PR workflow.
 
 ## Objective
-Automatically set up a dedicated `git worktree`, implement the requested fix, submit a PR with correct closure language, and clean up the environment.
+Automatically set up a dedicated `git worktree`, implement the requested fix, submit a PR with correct closure language, and keep the worktree available until the user confirms cleanup.
 
 ## The Standard Protocol
 

--- a/.github/skills/issue-worktree/SKILL.md
+++ b/.github/skills/issue-worktree/SKILL.md
@@ -12,16 +12,22 @@ Automatically set up a dedicated `git worktree`, implement the requested fix, su
 - Verify the base branch exists (usually `main`).
 
 ### 2. Workspace Setup
+- Verify which base branch exists (usually `main`) and use that verified branch in the setup commands below.
 - Create a dedicated worktree:
   ```bash
   export ISSUE_ID="<id>"
-  git worktree add .workspaces/$ISSUE_ID -b fix/$ISSUE_ID main
+  export BASE_BRANCH="<verified-base-branch>"
+  git worktree add .workspaces/$ISSUE_ID -b fix/$ISSUE_ID "$BASE_BRANCH"
+  ```
+- Add `.workspaces/` to your local exclude list to prevent accidental commits:
+  ```bash
+  echo ".workspaces" >> .git/info/exclude
   ```
 - All subsequent operations MUST be performed inside `.workspaces/$ISSUE_ID`.
 
 ### 3. Implementation Ritual
 - **Step 1: Test Baseline.** Run existing tests if they exist to confirm the current state.
-- **Step 2: Surgical Edit.** Apply changes following the "Surgical Changes" rule in `copilot-instructions.md`.
+- **Step 2: Surgical Edit.** Apply changes following the "Surgical Changes" rule in the Copilot instructions.
 - **Step 3: Verification.** Run tests to confirm the fix works and no regressions were introduced.
 
 ### 4. The Pull Request
@@ -29,7 +35,7 @@ Automatically set up a dedicated `git worktree`, implement the requested fix, su
 - Push the branch: `git push -u origin fix/$ISSUE_ID`.
 - Create the PR:
   ```bash
-  gh pr create --title "fix: resolution for #$ISSUE_ID" --body "## Summary\n\n[Description of changes]\n\nCloses #$ISSUE_ID"
+  gh pr create --title "fix: resolution for #$ISSUE_ID" --body $'## Summary\n\n[Description of changes]\n\nCloses #$ISSUE_ID'
   ```
 
 ### 5. Cleanup (Post-Verification)

--- a/README.md
+++ b/README.md
@@ -36,18 +36,23 @@ curl -Lo .copilot/instructions \
 
 Add project-specific rules to `.copilot/instructions` after downloading. Re-run the curl command to update with the latest shared standards.
 
-### Option 3: Global Skills (For Advanced Agents)
 ### Option 3: Per-Project Skills (For VS Code Copilot)
 
 Copy skills into your project's `.github/skills/` folder. VS Code Copilot discovers and loads them on-demand when relevant:
 
 ```bash
 mkdir -p .github/skills
-curl -Lo .github/skills/autonomous-worktree/SKILL.md --create-dirs \
-   https://raw.githubusercontent.com/bcgov/copilot-instructions/main/.github/skills/autonomous-worktree/SKILL.md
+curl -Lo .github/skills/issue-worktree/SKILL.md --create-dirs \
+   https://raw.githubusercontent.com/bcgov/copilot-instructions/main/.github/skills/issue-worktree/SKILL.md
 ```
 
-This makes the **Autonomous Worktree** skill available in your project. Add more skills from this repo as needed.
+This makes the **Issue Worktree** skill available in your project. Add more skills from this repo as needed.
+
+Use skills by asking normally in chat. You do not need a slash command. Prompts that match this skill include:
+
+- `Solve issue #123 in a worktree`
+- `Work on issue #123 in an isolated worktree and open a PR`
+- `Use the issue worktree workflow for issue #123`
 
 ## Safety Setup (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Guidelines and tooling to help developers effectively use GitHub Copilot while m
 ## What's Included
 
 - **[Copilot Instructions](/.github/copilot-instructions.md)** - Behavioral guidelines and coding standards that you can load into Copilot Chat
+- **[Skills](/.github/skills)** - Autonomous workflow playbooks loaded on-demand by VS Code Copilot
 - **Safety Tooling** (optional) - Git hooks and shell wrappers that enforce the instructions' safety rules
 - **Git Configuration Setup** (optional) - Recommended settings, global gitignore, and user configuration
 
@@ -34,6 +35,19 @@ curl -Lo .copilot/instructions \
 ```
 
 Add project-specific rules to `.copilot/instructions` after downloading. Re-run the curl command to update with the latest shared standards.
+
+### Option 3: Global Skills (For Advanced Agents)
+### Option 3: Per-Project Skills (For VS Code Copilot)
+
+Copy skills into your project's `.github/skills/` folder. VS Code Copilot discovers and loads them on-demand when relevant:
+
+```bash
+mkdir -p .github/skills
+curl -Lo .github/skills/autonomous-worktree/SKILL.md --create-dirs \
+   https://raw.githubusercontent.com/bcgov/copilot-instructions/main/.github/skills/autonomous-worktree/SKILL.md
+```
+
+This makes the **Autonomous Worktree** skill available in your project. Add more skills from this repo as needed.
 
 ## Safety Setup (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Add project-specific rules to `.copilot/instructions` after downloading. Re-run 
 Copy skills into your project's `.github/skills/` folder. VS Code Copilot discovers and loads them on-demand when relevant:
 
 ```bash
-mkdir -p .github/skills
 curl -Lo .github/skills/issue-worktree/SKILL.md --create-dirs \
    https://raw.githubusercontent.com/bcgov/copilot-instructions/main/.github/skills/issue-worktree/SKILL.md
 ```

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ Use skills by asking normally in chat. You do not need a slash command. Prompts 
 - `Work on issue #123 in an isolated worktree and open a PR`
 - `Use the issue worktree workflow for issue #123`
 
+## How Skills Work
+
+**Instructions** and **skills** are both placed under `.github/` but behave differently:
+
+| | Instructions | Skills |
+|---|---|---|
+| Loading | Always-on — injected into every chat | On-demand — loaded only when relevant |
+| Purpose | Standing rules and coding standards | Step-by-step workflows for specific tasks |
+| Trigger | Automatic | Natural language request |
+
+Skills are not slash commands. You invoke them by describing the job in plain language. VS Code Copilot matches your request against the skill name, title, and description, then loads and follows the playbook.
+
+**Tips for reliable activation:**
+- Use the job description, not the skill name. Ask for what you want done.
+- Include the key words from the skill's domain: "issue", "worktree", "PR".
+- If Copilot doesn't pick it up, mention the skill explicitly: "use the issue worktree workflow."
+
 ## Safety Setup (Recommended)
 
 The Copilot instructions tell the AI "never push to main", "never merge PRs", and "never run git config." This installer enforces those rules with git hooks and shell wrappers:


### PR DESCRIPTION
## Summary

This repo is focused on GitHub Copilot (VS Code). Skills were previously in `skills/` which no agent discovered automatically. This PR:

- Moves `skills/autonomous-worktree/` → `.github/skills/autonomous-worktree/` so VS Code Copilot loads skills natively
- Rewrites the README Option 3 section to replace Antigravity/Gemini symlink instructions with a `curl`-based per-project install for VS Code Copilot
- Updates the "What's Included" bullet to reflect the correct path