### PR TITLE
skill: add ESLint v9+ upgrade skill

### DIFF
--- a/.github/skills/eslint-upgrade/SKILL.md
+++ b/.github/skills/eslint-upgrade/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: eslint-upgrade
+description: Upgrade ESLint to v9+. Use when migrating from .eslintrc.* to flat config (eslint.config.mjs).
+---
+
 # ESLint 9+ Upgrade
 
 Guide for upgrading to ESLint v9+ which requires migrating from `.eslintrc.*` to flat config (`eslint.config.mjs`).

--- a/.github/skills/eslint-upgrade/SKILL.md
+++ b/.github/skills/eslint-upgrade/SKILL.md
@@ -1,0 +1,188 @@
+# ESLint 9+ Upgrade
+
+Guide for upgrading to ESLint v9+ which requires migrating from `.eslintrc.*` to flat config (`eslint.config.mjs`).
+
+## Overview
+
+ESLint v9+ uses flat config (ESM `.mjs` files) instead of the legacy `.eslintrc.json` / `.eslintrc.js` format. This is a breaking change in ESLint v9.
+
+## Example Reference
+
+See `bcgov/quickstart-openshift` for a working example:
+- https://github.com/bcgov/quickstart-openshift/blob/main/eslint-base.config.mjs
+
+## Dependencies Required
+
+### Frontend (Angular)
+```json
+"devDependencies": {
+  "eslint": "^9.0.0",
+  "eslint-config-prettier": "^9.0.0",
+  "typescript-eslint": "^8.0.0",
+  "@angular-eslint/eslint-plugin": "^18.0.0",
+  "@angular-eslint/eslint-plugin-template": "^18.0.0",
+  "@angular-eslint/template-parser": "^18.0.0"
+}
+```
+
+### Backend (NestJS/Node)
+```json
+"devDependencies": {
+  "eslint": "^9.0.0",
+  "eslint-config-prettier": "^9.0.0",
+  "typescript-eslint": "^8.0.0"
+}
+```
+
+## Migration Steps
+
+### 1. Create Project Config Files
+
+#### Angular Frontend (`admin/eslint.config.mjs` or `public/eslint.config.mjs`):
+```javascript
+import { FlatCompat } from '@eslint/js'
+import angular from '@angular-eslint/eslint-plugin'
+import angularParser from '@angular-eslint/template-parser'
+import angularTemplate from '@angular-eslint/eslint-plugin-template'
+import tseslint from 'typescript-eslint'
+import prettier from 'eslint-config-prettier'
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+})
+
+export default [
+  {
+    ignores: ['projects/**/*', 'dist/**', 'node_modules/**', 'coverage/**'],
+  },
+  ...tsseslint.configs['recommended'],
+  {
+    files: ['**/*.ts'],
+    plugins: {
+      '@angular-eslint': angular,
+    },
+    languageOptions: {
+      parser: angularParser,
+      parserOptions: {
+        project: 'tsconfig.json',
+      },
+    },
+  },
+  {
+    files: ['**/*.html'],
+    plugins: {
+      '@angular-eslint/template': angularTemplate,
+    },
+  },
+  {
+    files: ['**/*.ts'],
+    rules: {
+      '@angular-eslint/component-selector': [
+        'error',
+        { prefix: 'app', style: 'kebab-case', type: 'element' },
+      ],
+      '@angular-eslint/directive-selector': [
+        'error',
+        { prefix: 'app', style: 'camelCase', type: 'attribute' },
+      ],
+    },
+  },
+  {
+    rules: {
+      'prettier/prettier': 'error',
+    },
+  },
+  prettier,
+]
+```
+
+#### Backend API (`api/eslint.config.mjs`):
+```javascript
+import tseslint from 'typescript-eslint'
+import prettier from 'eslint-config-prettier'
+
+export default [
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**', '.eslintrc.js'],
+  },
+  ...tsseslint.configs['recommended'],
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: 'tsconfig.json',
+        sourceType: 'module',
+      },
+    },
+  },
+  {
+    rules: {
+      '@typescript-eslint/interface-name-prefix': 'off',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      'prettier/prettier': 'error',
+    },
+  },
+  prettier,
+]
+```
+
+### 2. Update angular.json
+
+Add `eslintConfig` option to the lint builder:
+
+```json
+"lint": {
+  "builder": "@angular-eslint/builder:lint",
+  "options": {
+    "eslintConfig": "eslint.config.mjs",
+    "lintFilePatterns": [
+      "src/**/*.ts",
+      "src/**/*.html"
+    ]
+  }
+}
+```
+
+### 3. Remove Legacy Config Files
+
+Delete:
+- `.eslintrc.json`
+- `.eslintrc.js`
+
+### 4. Test the Migration
+
+```bash
+# Run lint to verify
+npm run lint
+
+# Or for Angular projects
+ng lint
+```
+
+## Key Differences
+
+| Legacy (.eslintrc) | Flat Config (eslint.config.mjs) |
+|-------------------|--------------------------------|
+| JSON/YAML format | JavaScript (ESM) |
+| Hierarchical with overrides | Array of config objects |
+| `extends` array | Import and spread configs |
+| Parser in plugins | Uses `@typescript-eslint/parser` |
+
+## Troubleshooting
+
+### "Cannot find module '@angular-eslint/eslint-plugin'"
+Install:
+```bash
+npm install --save-dev @angular-eslint/eslint-plugin @angular-eslint/eslint-plugin-template @angular-eslint/template-parser
+```
+
+### "Flat Compat" not found
+Install:
+```bash
+npm install --save-dev @eslint/js
+```
+
+### Prettier conflicts
+Ensure `prettier` is last in the config array and `eslint-config-prettier` is in dependencies.

--- a/.github/skills/eslint-upgrade/SKILL.md
+++ b/.github/skills/eslint-upgrade/SKILL.md
@@ -18,6 +18,8 @@ See `bcgov/quickstart-openshift` for a working example:
 "devDependencies": {
   "eslint": "^9.0.0",
   "eslint-config-prettier": "^9.0.0",
+  "eslint-plugin-prettier": "^5.0.0",
+  "prettier": "^3.0.0",
   "typescript-eslint": "^8.0.0",
   "@angular-eslint/eslint-plugin": "^18.0.0",
   "@angular-eslint/eslint-plugin-template": "^18.0.0",
@@ -30,6 +32,8 @@ See `bcgov/quickstart-openshift` for a working example:
 "devDependencies": {
   "eslint": "^9.0.0",
   "eslint-config-prettier": "^9.0.0",
+  "eslint-plugin-prettier": "^5.0.0",
+  "prettier": "^3.0.0",
   "typescript-eslint": "^8.0.0"
 }
 ```
@@ -40,29 +44,24 @@ See `bcgov/quickstart-openshift` for a working example:
 
 #### Angular Frontend (`admin/eslint.config.mjs` or `public/eslint.config.mjs`):
 ```javascript
-import { FlatCompat } from '@eslint/js'
-import angular from '@angular-eslint/eslint-plugin'
-import angularParser from '@angular-eslint/template-parser'
-import angularTemplate from '@angular-eslint/eslint-plugin-template'
 import tseslint from 'typescript-eslint'
+import angular from '@angular-eslint/eslint-plugin'
+import angularTemplate from '@angular-eslint/eslint-plugin-template'
+import angularParser from '@angular-eslint/template-parser'
 import prettier from 'eslint-config-prettier'
-
-const compat = new FlatCompat({
-  baseDirectory: import.meta.dirname,
-})
 
 export default [
   {
     ignores: ['projects/**/*', 'dist/**', 'node_modules/**', 'coverage/**'],
   },
-  ...tsseslint.configs['recommended'],
+  ...tseslint.configs['recommended'],
   {
     files: ['**/*.ts'],
     plugins: {
       '@angular-eslint': angular,
     },
     languageOptions: {
-      parser: angularParser,
+      parser: tseslint.parser,
       parserOptions: {
         project: 'tsconfig.json',
       },
@@ -72,6 +71,9 @@ export default [
     files: ['**/*.html'],
     plugins: {
       '@angular-eslint/template': angularTemplate,
+    },
+    languageOptions: {
+      parser: angularParser,
     },
   },
   {
@@ -87,11 +89,6 @@ export default [
       ],
     },
   },
-  {
-    rules: {
-      'prettier/prettier': 'error',
-    },
-  },
   prettier,
 ]
 ```
@@ -105,7 +102,7 @@ export default [
   {
     ignores: ['dist/**', 'node_modules/**', 'coverage/**', '.eslintrc.js'],
   },
-  ...tsseslint.configs['recommended'],
+  ...tseslint.configs['recommended'],
   {
     files: ['**/*.ts'],
     languageOptions: {
@@ -121,7 +118,6 @@ export default [
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
-      'prettier/prettier': 'error',
     },
   },
   prettier,
@@ -178,11 +174,5 @@ Install:
 npm install --save-dev @angular-eslint/eslint-plugin @angular-eslint/eslint-plugin-template @angular-eslint/template-parser
 ```
 
-### "Flat Compat" not found
-Install:
-```bash
-npm install --save-dev @eslint/js
-```
-
 ### Prettier conflicts
-Ensure `prettier` is last in the config array and `eslint-config-prettier` is in dependencies.
+Ensure `prettier` is last in the config array and `eslint-config-prettier` is in dependencies. Do not enable `prettier/prettier` rule unless using `eslint-plugin-prettier`.

--- a/.github/skills/eslint-upgrade/SKILL.md
+++ b/.github/skills/eslint-upgrade/SKILL.md
@@ -8,18 +8,125 @@ ESLint v9+ uses flat config (ESM `.mjs` files) instead of the legacy `.eslintrc.
 
 ## Example Reference
 
-See `bcgov/quickstart-openshift` for a working example:
+See `bcgov/quickstart-openshift` for the canonical example:
 - https://github.com/bcgov/quickstart-openshift/blob/main/eslint-base.config.mjs
 
 ## Dependencies Required
 
-### Frontend (Angular)
 ```json
 "devDependencies": {
   "eslint": "^9.0.0",
   "eslint-config-prettier": "^9.0.0",
-  "eslint-plugin-prettier": "^5.0.0",
-  "prettier": "^3.0.0",
+  "typescript-eslint": "^8.0.0"
+}
+```
+
+For React/Vite projects, add:
+```json
+"@eslint/js": "^9.0.0"
+```
+
+## Migration Steps
+
+### 1. Create Flat Config
+
+Create `eslint.config.mjs` in your project root:
+
+```javascript
+import tseslint from 'typescript-eslint'
+import prettier from 'eslint-config-prettier'
+
+export default [
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**', 'vite.config.*', 'vitest.config.*'],
+  },
+  ...tseslint.configs['recommended'],
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: 'tsconfig.json',
+      },
+    },
+  },
+  prettier,
+]
+```
+
+### 2. Framework-Specific Notes
+
+#### React/Vite
+For React projects using Vite, use the recommended config from `@eslint/js`:
+
+```javascript
+import tseslint from 'typescript-eslint'
+import eslintPluginReact from 'eslint-plugin-react'
+import eslintPluginReactHooks from 'eslint-plugin-react-hooks'
+import prettier from 'eslint-config-prettier'
+
+export default [
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
+  },
+  ...tseslint.configs['recommended'],
+  {
+    files: ['**/*.{ts,tsx}'],
+    plugins: {
+      react: eslintPluginReact,
+      'react-hooks': eslintPluginReactHooks,
+    },
+    languageOptions: {
+      parserOptions: {
+        project: 'tsconfig.json',
+      },
+    },
+    rules: {
+      ...eslintPluginReact.configs.recommended.rules,
+      ...eslintPluginReactHooks.configs.recommended.rules,
+    },
+  },
+  prettier,
+]
+```
+
+#### NestJS/Backend
+NestJS projects may need additional rules disabled:
+
+```javascript
+import tseslint from 'typescript-eslint'
+import prettier from 'eslint-config-prettier'
+
+export default [
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
+  },
+  ...tseslint.configs['recommended'],
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: 'tsconfig.json',
+        sourceType: 'module',
+      },
+    },
+  },
+  {
+    rules: {
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+    },
+  },
+  prettier,
+]
+```
+
+#### Angular
+Angular requires `@angular-eslint` packages:
+
+```json
+"devDependencies": {
+  "eslint": "^9.0.0",
+  "eslint-config-prettier": "^9.0.0",
   "typescript-eslint": "^8.0.0",
   "@angular-eslint/eslint-plugin": "^18.0.0",
   "@angular-eslint/eslint-plugin-template": "^18.0.0",
@@ -27,22 +134,6 @@ See `bcgov/quickstart-openshift` for a working example:
 }
 ```
 
-### Backend (NestJS/Node)
-```json
-"devDependencies": {
-  "eslint": "^9.0.0",
-  "eslint-config-prettier": "^9.0.0",
-  "eslint-plugin-prettier": "^5.0.0",
-  "prettier": "^3.0.0",
-  "typescript-eslint": "^8.0.0"
-}
-```
-
-## Migration Steps
-
-### 1. Create Project Config Files
-
-#### Angular Frontend (`admin/eslint.config.mjs` or `public/eslint.config.mjs`):
 ```javascript
 import tseslint from 'typescript-eslint'
 import angular from '@angular-eslint/eslint-plugin'
@@ -57,104 +148,38 @@ export default [
   ...tseslint.configs['recommended'],
   {
     files: ['**/*.ts'],
-    plugins: {
-      '@angular-eslint': angular,
-    },
+    plugins: { '@angular-eslint': angular },
     languageOptions: {
       parser: tseslint.parser,
-      parserOptions: {
-        project: 'tsconfig.json',
-      },
+      parserOptions: { project: 'tsconfig.json' },
     },
   },
   {
     files: ['**/*.html'],
-    plugins: {
-      '@angular-eslint/template': angularTemplate,
-    },
-    languageOptions: {
-      parser: angularParser,
-    },
-  },
-  {
-    files: ['**/*.ts'],
-    rules: {
-      '@angular-eslint/component-selector': [
-        'error',
-        { prefix: 'app', style: 'kebab-case', type: 'element' },
-      ],
-      '@angular-eslint/directive-selector': [
-        'error',
-        { prefix: 'app', style: 'camelCase', type: 'attribute' },
-      ],
-    },
+    plugins: { '@angular-eslint/template': angularTemplate },
+    languageOptions: { parser: angularParser },
   },
   prettier,
 ]
 ```
 
-#### Backend API (`api/eslint.config.mjs`):
-```javascript
-import tseslint from 'typescript-eslint'
-import prettier from 'eslint-config-prettier'
-
-export default [
-  {
-    ignores: ['dist/**', 'node_modules/**', 'coverage/**', '.eslintrc.js'],
-  },
-  ...tseslint.configs['recommended'],
-  {
-    files: ['**/*.ts'],
-    languageOptions: {
-      parserOptions: {
-        project: 'tsconfig.json',
-        sourceType: 'module',
-      },
-    },
-  },
-  {
-    rules: {
-      '@typescript-eslint/interface-name-prefix': 'off',
-      '@typescript-eslint/explicit-function-return-type': 'off',
-      '@typescript-eslint/explicit-module-boundary-types': 'off',
-      '@typescript-eslint/no-explicit-any': 'off',
-    },
-  },
-  prettier,
-]
-```
-
-### 2. Update angular.json
-
-Add `eslintConfig` option to the lint builder:
-
+Update `angular.json` to use the new config:
 ```json
 "lint": {
-  "builder": "@angular-eslint/builder:lint",
   "options": {
-    "eslintConfig": "eslint.config.mjs",
-    "lintFilePatterns": [
-      "src/**/*.ts",
-      "src/**/*.html"
-    ]
+    "eslintConfig": "eslint.config.mjs"
   }
 }
 ```
 
-### 3. Remove Legacy Config Files
+### 3. Remove Legacy Config
 
-Delete:
-- `.eslintrc.json`
-- `.eslintrc.js`
+Delete: `.eslintrc.json`, `.eslintrc.js`, `.eslintrc.*`
 
-### 4. Test the Migration
+### 4. Test
 
 ```bash
-# Run lint to verify
 npm run lint
-
-# Or for Angular projects
-ng lint
 ```
 
 ## Key Differences
@@ -164,15 +189,13 @@ ng lint
 | JSON/YAML format | JavaScript (ESM) |
 | Hierarchical with overrides | Array of config objects |
 | `extends` array | Import and spread configs |
-| Parser in plugins | Uses `@typescript-eslint/parser` |
 
 ## Troubleshooting
 
-### "Cannot find module '@angular-eslint/eslint-plugin'"
-Install:
+### "Cannot find module 'typescript-eslint'"
 ```bash
-npm install --save-dev @angular-eslint/eslint-plugin @angular-eslint/eslint-plugin-template @angular-eslint/template-parser
+npm install --save-dev typescript-eslint
 ```
 
 ### Prettier conflicts
-Ensure `prettier` is last in the config array and `eslint-config-prettier` is in dependencies. Do not enable `prettier/prettier` rule unless using `eslint-plugin-prettier`.
+Ensure `eslint-config-prettier` is last in the config array.

--- a/.github/skills/eslint-upgrade/SKILL.md
+++ b/.github/skills/eslint-upgrade/SKILL.md
@@ -177,11 +177,97 @@ Update `angular.json` to use the new config:
 }
 ```
 
-### 3. Remove Legacy Config
+### 3. Handle Legacy Config
 
-Delete: `.eslintrc.json`, `.eslintrc.js`, `.eslintrc.*`
+#### .eslintignore
+Flat config uses `ignores` in the first config object instead of `.eslintignore`. Migrate patterns:
 
-### 4. Test
+| .eslintignore | ignores in flat config |
+|---------------|------------------------|
+| `node_modules/` | `'node_modules/**'` |
+| `dist/` | `'dist/**'` |
+| `*.config.js` | `'*.config.js'` |
+
+```javascript
+export default [
+  {
+    ignores: [
+      'dist/**',
+      'node_modules/**',
+      'coverage/**',
+      'build/**',
+      '*.config.js',
+      '*.config.mjs',
+    ],
+  },
+  // ... rest of config
+]
+```
+
+#### Legacy Plugins (FlatCompat)
+For plugins without flat config support, use `FlatCompat` from `@eslint/eslintrc`:
+
+```bash
+npm install --save-dev @eslint/eslintrc
+```
+
+```javascript
+import { FlatCompat } from '@eslint/eslintrc'
+import someLegacyPlugin from 'eslint-plugin-some-legacy'
+
+const compat = new FlatCompat({
+  baseDirectory: import.meta.dirname,
+})
+
+export default [
+  // ... base config
+  ...compat.plugins(someLegacyPlugin),
+  {
+    rules: {
+      'some-legacy/some-rule': 'error',
+    },
+  },
+]
+```
+
+### 4. Extending Multiple Configs
+
+Combine base config with project-specific overrides:
+
+```javascript
+import tseslint from 'typescript-eslint'
+import baseConfig from './eslint-base.config.mjs'
+import prettier from 'eslint-config-prettier'
+
+export default [
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**'],
+  },
+  ...tseslint.configs['recommended'],
+  ...baseConfig,  // import shared rules from another config
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: 'tsconfig.json',
+      },
+    },
+  },
+  {
+    rules: {
+      // Project-specific overrides
+      '@typescript-eslint/no-unused-vars': 'warn',
+    },
+  },
+  prettier,
+]
+```
+
+### 5. Remove Legacy Config
+
+Delete: `.eslintrc.json`, `.eslintrc.js`, `.eslintrc.*`, `.eslintignore`
+
+### 6. Test
 
 ```bash
 npm run lint
@@ -202,5 +288,32 @@ npm run lint
 npm install --save-dev typescript-eslint
 ```
 
+### "Flat Compat" not found
+FlatCompat is in `@eslint/eslintrc`, not `@eslint/js`:
+```bash
+npm install --save-dev @eslint/eslintrc
+```
+
+### Legacy plugins without flat config
+Use FlatCompat to wrap legacy plugins:
+```javascript
+import { FlatCompat } from '@eslint/eslintrc'
+```
+
 ### Prettier conflicts
 Ensure `eslint-config-prettier` is last in the config array.
+
+### Common Errors
+
+| Error | Solution |
+|-------|----------|
+| "Definition for rule ... was not found" | Plugin not loaded or rule doesn't exist in flat config |
+| "Cannot find module" | Missing package in devDependencies |
+| "ESLint is not a constructor" | Config file format issue; ensure ESM with `.mjs` extension |
+
+### Deeper Troubleshooting
+
+Search for specific error messages:
+- "eslint-plugin-xxx flat config"
+- "eslint v9 plugin migration"
+- "typescript-eslint flat config" if you have issues with tsconfig parsing


### PR DESCRIPTION
## Summary

- Adds `.github/skills/eslint-upgrade/` skill for migrating ESLint to v9+
- Generic config as primary example (TypeScript + typescript-eslint)
- Framework-specific sections: React/Vite, NestJS/Backend, Angular
- Uses quickstart-openshift as canonical reference
- Added frontmatter for proper skill discovery
- Fixed config issues: typos, parser assignments, prettier setup