### PR TITLE
feat: add 'Sync' command for automated PR reconciliation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,6 +45,7 @@
 1. **Branching:** **ALWAYS** run `git checkout main && git pull && git switch -c feat/description` before making any changes.
 2. **PR Creation:** **ALWAYS** run `git fetch origin && git rebase origin/main && git log origin/main..HEAD --oneline` before pushing; **STOP** if unintended commits appear.
 3. **Closing:** **ALWAYS** end PR bodies with `Closes #<number>` if a task references a GitHub issue.
+4. **Syncing:** When asked to **"Sync #number"**, **ALWAYS**: rebase the PR branch onto latest `main`, review `gh pr view --comments`, and check `gh pr checks` for failures. Address all feedback and CI errors before pushing.
 
 ### Project Standards
 - **ALWAYS** use Conventional Commits with scoped, descriptive messages.


### PR DESCRIPTION
## Summary

Adds a high-level "Sync" command to the Git Workflow that allows users to trigger a full PR reconciliation mission with a single shorthand.

### How to use
When you say **"Sync #94"**, the AI will:
1. Rebase the branch onto the latest `main`.
2. Review all `gh pr view --comments` (human or bot feedback).
3. Check `gh pr checks` for CI/CD failures.
4. Address all issues and failures in a single, atomic push.

This turns the AI into a self-healing CI agent.