### PR TITLE
feat: dependency regression check hook

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -8,3 +8,32 @@ if ! command -v gitleaks >/dev/null 2>&1; then
 fi
 
 gitleaks protect --staged --redact --no-banner
+
+# ─── General Regression Guardian ───────────────────────────────────────────
+# Detects and blocks accidental version downgrades in config files.
+# Supports Docker (FROM), Node (package.json), Actions (uses), and Python (requires-python).
+
+STAGED_FILES=$(git diff --cached --name-only)
+
+# Heuristic check for version regressions
+# We look for lines removed with a higher version and lines added with a lower version.
+for file in $STAGED_FILES; do
+    if [[ "$file" =~ (package.json|Containerfile|Dockerfile|compose.yml|docker-compose.yml|pyproject.toml|.github/workflows/.*\.yml)$ ]]; then
+        # Check for common versioning patterns
+        # Look for -node:20 / +node:18 style regressions
+        REGRESSION=$(git diff --cached "$file" | grep -E "^\-(.*)([0-9]+\.[0-9]+)" | grep -oE "[0-9]+\.[0-9]+" | head -n 1)
+        NEW_VERSION=$(git diff --cached "$file" | grep -E "^\+(.*)([0-9]+\.[0-9]+)" | grep -oE "[0-9]+\.[0-9]+" | head -n 1)
+
+        if [[ -n "$REGRESSION" ]] && [[ -n "$NEW_VERSION" ]]; then
+            # Simple numeric comparison for major.minor
+            # Requires 'bc' for floating point comparison. If missing, this check is skipped.
+            if command -v bc >/dev/null 2>&1; then
+                if (( $(echo "$NEW_VERSION < $REGRESSION" | bc -l) )); then
+                    echo -e "\033[0;31mERROR: Version regression detected in $file ($REGRESSION -> $NEW_VERSION)!\033[0m" >&2
+                    echo "AI Agents are FORBIDDEN from downgrading versions without explicit user discussion." >&2
+                    exit 1
+                fi
+            fi
+        fi
+    fi
+done

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 if ! command -v gitleaks >/dev/null 2>&1; then
-  echo "BLOCKED: gitleaks not found. Run scripts/setup.sh to install." >&2
+  echo "BLOCKED: gitleaks not found. Run scripts/install-hooks.sh to install." >&2
   exit 1
 fi
 
@@ -13,27 +13,26 @@ gitleaks protect --staged --redact --no-banner
 # Detects and blocks accidental version downgrades in config files.
 # Supports Docker (FROM), Node (package.json), Actions (uses), and Python (requires-python).
 
-STAGED_FILES=$(git diff --cached --name-only)
+# Use null-delimited find to handle spaces/newlines in filenames
+git diff --cached --name-only -z | while IFS= read -r -d '' file; do
+  if [[ "$file" =~ (package.json|Containerfile|Dockerfile|compose.yml|docker-compose.yml|pyproject.toml|\.github/workflows/.*\.ya?ml)$ ]]; then
+    # Extract versions (heuristic)
+    # We look for lines removed (-) and added (+) that look like versions.
+    # Pattern matches standard versioning (X.X.X, X.X, vX)
+    REGRESSION=$(git diff --cached "$file" | grep -E "^\-" | grep -oE "[0-9]+(\.[0-9]+)+" | head -n 1 || true)
+    NEW_VERSION=$(git diff --cached "$file" | grep -E "^\+" | grep -oE "[0-9]+(\.[0-9]+)+" | head -n 1 || true)
 
-# Heuristic check for version regressions
-# We look for lines removed with a higher version and lines added with a lower version.
-for file in $STAGED_FILES; do
-    if [[ "$file" =~ (package.json|Containerfile|Dockerfile|compose.yml|docker-compose.yml|pyproject.toml|.github/workflows/.*\.yml)$ ]]; then
-        # Check for common versioning patterns
-        # Look for -node:20 / +node:18 style regressions
-        REGRESSION=$(git diff --cached "$file" | grep -E "^\-(.*)([0-9]+\.[0-9]+)" | grep -oE "[0-9]+\.[0-9]+" | head -n 1)
-        NEW_VERSION=$(git diff --cached "$file" | grep -E "^\+(.*)([0-9]+\.[0-9]+)" | grep -oE "[0-9]+\.[0-9]+" | head -n 1)
-
-        if [[ -n "$REGRESSION" ]] && [[ -n "$NEW_VERSION" ]]; then
-            # Simple numeric comparison for major.minor
-            # Requires 'bc' for floating point comparison. If missing, this check is skipped.
-            if command -v bc >/dev/null 2>&1; then
-                if (( $(echo "$NEW_VERSION < $REGRESSION" | bc -l) )); then
-                    echo -e "\033[0;31mERROR: Version regression detected in $file ($REGRESSION -> $NEW_VERSION)!\033[0m" >&2
-                    echo "AI Agents are FORBIDDEN from downgrading versions without explicit user discussion." >&2
-                    exit 1
-                fi
-            fi
-        fi
+    if [[ -n "$REGRESSION" ]] && [[ -n "$NEW_VERSION" ]]; then
+      # Compare versions correctly using sort -V (Version Sort)
+      # 1.10 is newer than 1.9
+      LOWER_VERSION=$(printf "%s\n%s" "$REGRESSION" "$NEW_VERSION" | sort -V | head -n 1)
+      
+      # If the lowest version in the set is the NEW version, and they aren't equal, it's a regression.
+      if [[ "$LOWER_VERSION" == "$NEW_VERSION" ]] && [[ "$NEW_VERSION" != "$REGRESSION" ]]; then
+        echo -e "\033[0;31mERROR: Version regression detected in $file ($REGRESSION -> $NEW_VERSION)!\033[0m" >&2
+        echo "AI Agents are FORBIDDEN from downgrading versions without explicit user discussion." >&2
+        exit 1
+      fi
     fi
+  fi
 done


### PR DESCRIPTION
This PR adds a general version regression detector to the pre-commit hook. It blocks any numerical version decrease in config files (Node, Docker, Actions, Python) to prevent accidental AI-driven downgrades.