### PR TITLE
feat(safety): block AI PR merges and approvals in GitHub CLI

### DIFF
--- a/scripts/git-safety.sh
+++ b/scripts/git-safety.sh
@@ -27,13 +27,17 @@ git() {
 
         # Block config
         if [[ "$sub" == "config" ]]; then
-            echo "BLOCKED: git config is not allowed. Talk to the user." >&2
+            echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from modifying Git configuration." >&2
+            echo "         Changes to Git configuration could alter repository behavior and bypass safety rules." >&2
+            echo "         HALT immediately and request manual action from the USER." >&2
             return 1
         fi
 
         # Block tagging
         if [[ "$sub" == "tag" ]]; then
-            echo "BLOCKED: Tagging is restricted. AI is not allowed to cut releases. Talk to the user." >&2
+            echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from tagging commits." >&2
+            echo "         AI is not allowed to manage git tags or cut releases." >&2
+            echo "         HALT immediately and request manual action from the USER." >&2
             return 1
         fi
 
@@ -56,7 +60,9 @@ git() {
         fi
 
         if [[ "$is_destructive" == "true" ]]; then
-            echo "BLOCKED: Squashing or interactive rebasing destroys history and makes change review difficult. Never squash commits in PR branches." >&2
+            echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from squashing commits or interactive rebasing." >&2
+            echo "         Squashing destroys git history and makes change review difficult." >&2
+            echo "         HALT immediately and request manual action from the USER." >&2
             return 1
         fi
 
@@ -64,7 +70,9 @@ git() {
         if [[ "$sub" == "push" ]]; then
             for arg in "$@"; do
                 if echo "$arg" | grep -qE "^(--tags|--follow-tags|refs/tags/|.*:refs/tags/)"; then
-                    echo "BLOCKED: Pushing tags is restricted. AI is not allowed to cut releases. Talk to the user." >&2
+                    echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from pushing tags." >&2
+                    echo "         AI is not allowed to manage git tags or cut releases." >&2
+                    echo "         HALT immediately and request manual action from the USER." >&2
                     return 1
                 fi
             done
@@ -105,13 +113,19 @@ gh() {
         done
 
         if [[ "$cmd" == "release" ]]; then
-            echo "BLOCKED: Release operations are restricted. AI is not allowed to cut releases. Talk to the user." >&2
+            echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from managing GitHub Releases." >&2
+            echo "         AI is not allowed to cut releases or manage git tags." >&2
+            echo "         HALT immediately and request manual action from the USER." >&2
             return 1
         elif [[ "$cmd" == "repo" && "$sub" == "delete" ]]; then
-            echo "BLOCKED: Repository deletion is restricted. Talk to the user." >&2
+            echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from deleting repositories." >&2
+            echo "         Repository deletion is highly destructive and irreversible." >&2
+            echo "         HALT immediately and request manual action from the USER." >&2
             return 1
         elif [[ "$cmd" == "secret" ]]; then
-            echo "BLOCKED: Secret management is restricted. Talk to the user." >&2
+            echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from managing repository secrets." >&2
+            echo "         Secret management must be handled directly by the USER." >&2
+            echo "         HALT immediately." >&2
             return 1
         elif [[ "$cmd" == "pr" ]]; then
             if [[ "$sub" == "merge" ]]; then
@@ -151,7 +165,9 @@ oc() {
     fi
 
     if [[ "$is_completion" != "true" ]]; then
-        echo "BLOCKED: Running oc directly is restricted." >&2
+        echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from running OpenShift (oc) commands directly." >&2
+        echo "         Direct cluster interaction is restricted to ensure system stability." >&2
+        echo "         HALT immediately and request manual action from the USER." >&2
         return 1
     fi
 
@@ -168,7 +184,9 @@ kubectl() {
     fi
 
     if [[ "$is_completion" != "true" ]]; then
-        echo "BLOCKED: Running kubectl directly is restricted." >&2
+        echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from running Kubernetes (kubectl) commands directly." >&2
+        echo "         Direct cluster interaction is restricted to ensure system stability." >&2
+        echo "         HALT immediately and request manual action from the USER." >&2
         return 1
     fi
 
@@ -182,14 +200,18 @@ npm() {
     if [[ -z "${COMP_LINE:-}" && -z "${COMP_POINT:-}" ]]; then
         # Check environment bypass vector
         if [[ -n "${NPM_CONFIG_LEGACY_PEER_DEPS:-}" ]]; then
-            echo "BLOCKED: NPM_CONFIG_LEGACY_PEER_DEPS is set. Bypassing peer deps is forbidden." >&2
+            echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from bypassing peer dependencies." >&2
+            echo "         NPM_CONFIG_LEGACY_PEER_DEPS environment variable must not be set." >&2
+            echo "         HALT immediately and resolve peer dependency conflicts cleanly." >&2
             return 1
         fi
 
         # Check arguments for exact flags
         for arg in "$@"; do
             if [[ "$arg" == "--legacy-peer-deps" || "$arg" =~ ^--legacy-peer-deps= ]]; then
-                echo "BLOCKED: npm with --legacy-peer-deps is strictly forbidden. Resolve your peer dependency conflicts cleanly instead of bypassing them." >&2
+                echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from bypassing peer dependencies." >&2
+                echo "         npm with --legacy-peer-deps is strictly forbidden." >&2
+                echo "         HALT immediately and resolve peer dependency conflicts cleanly." >&2
                 return 1
             fi
         done
@@ -205,14 +227,18 @@ npx() {
     if [[ -z "${COMP_LINE:-}" && -z "${COMP_POINT:-}" ]]; then
         # Check environment bypass vector
         if [[ -n "${NPM_CONFIG_LEGACY_PEER_DEPS:-}" ]]; then
-            echo "BLOCKED: NPM_CONFIG_LEGACY_PEER_DEPS is set. Bypassing peer deps is forbidden." >&2
+            echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from bypassing peer dependencies." >&2
+            echo "         NPM_CONFIG_LEGACY_PEER_DEPS environment variable must not be set." >&2
+            echo "         HALT immediately and resolve peer dependency conflicts cleanly." >&2
             return 1
         fi
 
         # Check arguments for exact flags
         for arg in "$@"; do
             if [[ "$arg" == "--legacy-peer-deps" || "$arg" =~ ^--legacy-peer-deps= ]]; then
-                echo "BLOCKED: npx with --legacy-peer-deps is strictly forbidden. Resolve your peer dependency conflicts cleanly instead of bypassing them." >&2
+                echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from bypassing peer dependencies." >&2
+                echo "         npx with --legacy-peer-deps is strictly forbidden." >&2
+                echo "         HALT immediately and resolve peer dependency conflicts cleanly." >&2
                 return 1
             fi
         done
@@ -222,4 +248,3 @@ npx() {
 }
 
 export -f npx
-

--- a/scripts/git-safety.sh
+++ b/scripts/git-safety.sh
@@ -79,29 +79,58 @@ export -f git
 gh() {
     # Skip during tab completion
     if [[ -z "${COMP_LINE:-}" && -z "${COMP_POINT:-}" ]]; then
-        case "$1" in
-            release)
-                echo "BLOCKED: Release operations are restricted. AI is not allowed to cut releases. Talk to the user." >&2
-                return 1
-                ;;
-            pr)
-                if [[ "$2" == "merge" ]]; then
-                    echo "BLOCKED: PR merging is restricted. Talk to the user." >&2
-                    return 1
-                fi
-                ;;
-            repo)
-                if [[ "$2" == "delete" ]]; then
-                    echo "BLOCKED: Repository deletion is restricted. Talk to the user." >&2
-                    return 1
-                fi
-                ;;
-            secret)
-                echo "BLOCKED: Secret management is restricted. Talk to the user." >&2
-                return 1
-                ;;
-        esac
+        # Identify command and subcommand (skip global options like -R, --repo, etc.)
+        local cmd=""
+        local sub=""
+        local args=("$@")
+        local i=0
+        while [[ $i -lt ${#args[@]} ]]; do
+            case "${args[$i]}" in
+                -R|--repo|--app|--host)
+                    ((i+=2))
+                    ;;
+                -*)
+                    ((i+=1))
+                    ;;
+                *)
+                    if [[ -z "$cmd" ]]; then
+                        cmd="${args[$i]}"
+                    elif [[ -z "$sub" ]]; then
+                        sub="${args[$i]}"
+                        break
+                    fi
+                    ((i+=1))
+                    ;;
+            esac
+        done
 
+        if [[ "$cmd" == "release" ]]; then
+            echo "BLOCKED: Release operations are restricted. AI is not allowed to cut releases. Talk to the user." >&2
+            return 1
+        elif [[ "$cmd" == "repo" && "$sub" == "delete" ]]; then
+            echo "BLOCKED: Repository deletion is restricted. Talk to the user." >&2
+            return 1
+        elif [[ "$cmd" == "secret" ]]; then
+            echo "BLOCKED: Secret management is restricted. Talk to the user." >&2
+            return 1
+        elif [[ "$cmd" == "pr" ]]; then
+            if [[ "$sub" == "merge" ]]; then
+                echo "BLOCKED: PR merging is restricted. Talk to the user." >&2
+                return 1
+            elif [[ "$sub" == "review" ]]; then
+                local has_approve=false
+                for arg in "$@"; do
+                    if [[ "$arg" == "--approve" || "$arg" == "-a" ]]; then
+                        has_approve=true
+                        break
+                    fi
+                done
+                if [[ "$has_approve" == "true" ]]; then
+                    echo "BLOCKED: PR approval is restricted. AI is not allowed to approve PRs. Talk to the user." >&2
+                    return 1
+                fi
+            fi
+        fi
     fi
 
     command gh "$@"

--- a/scripts/git-safety.sh
+++ b/scripts/git-safety.sh
@@ -115,7 +115,10 @@ gh() {
             return 1
         elif [[ "$cmd" == "pr" ]]; then
             if [[ "$sub" == "merge" ]]; then
-                echo "BLOCKED: PR merging is restricted. Talk to the user." >&2
+                echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from merging Pull Requests." >&2
+                echo "         Under bcgov/copilot-instructions policy, all merges must be reviewed and executed manually by the USER." >&2
+                echo "         Do NOT attempt to bypass this block using absolute paths, alternate flags, or command overrides." >&2
+                echo "         HALT immediately and report to the user." >&2
                 return 1
             elif [[ "$sub" == "review" ]]; then
                 local has_approve=false
@@ -126,7 +129,9 @@ gh() {
                     fi
                 done
                 if [[ "$has_approve" == "true" ]]; then
-                    echo "BLOCKED: PR approval is restricted. AI is not allowed to approve PRs. Talk to the user." >&2
+                    echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from approving Pull Requests." >&2
+                    echo "         Self-approving or bypass-approving is a direct violation of repository security guardrails." >&2
+                    echo "         HALT immediately and request manual approval from the USER." >&2
                     return 1
                 fi
             fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -103,19 +103,35 @@ install_hooks() {
   command git config --global core.hooksPath "$HOOKS_DIR"
 }
 
+cleanup_old_bashrc_safety() {
+  local bashrc="$HOME/.bashrc"
+  if [[ -f "$bashrc" ]]; then
+    echo "Cleaning up old safety wrapper definitions from ~/.bashrc..."
+    python3 -c '
+import sys, re
+path = sys.argv[1]
+with open(path, "r") as f:
+    content = f.read()
+
+# Remove old git/gh wrapper blocks and any duplicate AI policy blocks
+content = re.sub(r"# Git Safety.*?\nexport -f git\n*", "", content, flags=re.DOTALL)
+content = re.sub(r"# GitHub CLI Safety.*?\nexport -f gh\n*", "", content, flags=re.DOTALL)
+content = re.sub(r"# AI POLICY \(bcgov/copilot-instructions\).*?\nexport -f (gh|npx)\n*", "", content, flags=re.DOTALL)
+
+# Remove trailing empty lines or excessive newlines
+content = re.sub(r"\n{3,}", "\n\n", content)
+
+with open(path, "w") as f:
+    f.write(content)
+' "$bashrc"
+  fi
+}
+
 install_gh_safety() {
   local bashrc="$HOME/.bashrc"
   local git_safety="$SCRIPT_DIR/git-safety.sh"
   
-  if grep -q '^gh()' "$bashrc" 2>/dev/null; then
-    echo "NOTE: gh() already exists in ~/.bashrc. Remove it to re-install the safety wrapper." >&2
-    return 0
-  fi
-
-  if grep -q "AI POLICY (bcgov/copilot-instructions)" "$bashrc" 2>/dev/null; then
-    echo "NOTE: Remove the existing AI POLICY block in ~/.bashrc to re-install it." >&2
-    return 0
-  fi
+  cleanup_old_bashrc_safety
 
   if [[ ! -f "$git_safety" ]]; then
     echo "ERROR: Could not find $git_safety" >&2
@@ -123,7 +139,11 @@ install_gh_safety() {
   fi
 
   # Append the gh safety function from git-safety.sh (skip shebang)
-  tail -n +2 "$git_safety" >> "$bashrc"
+  {
+    echo ""
+    echo "# AI POLICY (bcgov/copilot-instructions)"
+    tail -n +2 "$git_safety"
+  } >> "$bashrc"
   
   echo "Added GitHub CLI safety to ~/.bashrc"
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -107,15 +107,21 @@ cleanup_old_bashrc_safety() {
   local bashrc="$HOME/.bashrc"
   if [[ -f "$bashrc" ]]; then
     echo "Cleaning up old safety wrapper definitions from ~/.bashrc..."
-    python3 -c '
+    
+    if command -v python3 >/dev/null 2>&1; then
+      python3 -c '
 import sys, re
 path = sys.argv[1]
 with open(path, "r") as f:
     content = f.read()
 
-# Remove old git/gh wrapper blocks and any duplicate AI policy blocks
+# 1. Clean up the new marked block first if it exists
+content = re.sub(r"# >>> bcgov/copilot-instructions safety block >>>.*?# <<< bcgov/copilot-instructions safety block <<<\n*", "", content, flags=re.DOTALL)
+
+# 2. Clean up legacy/historical unmarked blocks safely (matching up to their specific exports)
 content = re.sub(r"# Git Safety.*?\nexport -f git\n*", "", content, flags=re.DOTALL)
 content = re.sub(r"# GitHub CLI Safety.*?\nexport -f gh\n*", "", content, flags=re.DOTALL)
+# Make sure we do not leave orphaned functions by matching through the entire old AI policy block
 content = re.sub(r"# AI POLICY \(bcgov/copilot-instructions\).*?\nexport -f (gh|npx)\n*", "", content, flags=re.DOTALL)
 
 # Remove trailing empty lines or excessive newlines
@@ -124,25 +130,50 @@ content = re.sub(r"\n{3,}", "\n\n", content)
 with open(path, "w") as f:
     f.write(content)
 ' "$bashrc"
+    else
+      echo "WARNING: python3 is not available. Skipping deep regex cleanup of old safety blocks." >&2
+      echo "         Any existing marked safety block will be cleaned up using basic sed." >&2
+      
+      # Securely strip marked block using sed fallback if present
+      if grep -q "# >>> bcgov/copilot-instructions safety block >>>" "$bashrc"; then
+        local temp_file
+        temp_file=$(mktemp)
+        sed '/# >>> bcgov/copilot-instructions safety block >>>/,/# <<< bcgov/copilot-instructions safety block <<</d' "$bashrc" > "$temp_file"
+        cat "$temp_file" > "$bashrc"
+        rm -f "$temp_file"
+      fi
+    fi
   fi
 }
 
 install_gh_safety() {
   local bashrc="$HOME/.bashrc"
   local git_safety="$SCRIPT_DIR/git-safety.sh"
+  local timestamp
+  timestamp=$(date +%s)
   
-  cleanup_old_bashrc_safety
-
+  # 1. Pre-flight check: Verify source file exists before modifying anything
   if [[ ! -f "$git_safety" ]]; then
-    echo "ERROR: Could not find $git_safety" >&2
+    echo "ERROR: Could not find safety source script at $git_safety" >&2
     return 1
   fi
 
-  # Append the gh safety function from git-safety.sh (skip shebang)
+  # 2. Pre-flight check: Create a backup of ~/.bashrc first
+  if [[ -f "$bashrc" ]]; then
+    cp "$bashrc" "$bashrc.bak.$timestamp"
+    echo "NOTE: Created backup of ~/.bashrc at $bashrc.bak.$timestamp" >&2
+  fi
+
+  # 3. Purge old blocks safely
+  cleanup_old_bashrc_safety
+
+  # 4. Append the gh safety function wrapped in explicit BEGIN/END markers (skip shebang)
   {
     echo ""
+    echo "# >>> bcgov/copilot-instructions safety block >>>"
     echo "# AI POLICY (bcgov/copilot-instructions)"
     tail -n +2 "$git_safety"
+    echo "# <<< bcgov/copilot-instructions safety block <<<"
   } >> "$bashrc"
   
   echo "Added GitHub CLI safety to ~/.bashrc"


### PR DESCRIPTION
### Summary
This PR closes the loop on rogue AI behavior by introducing robust safety blocks for `gh pr merge` and `gh pr review --approve` inside `git-safety.sh`.

### Key Changes
- **Upgraded GitHub CLI Wrapper:** Rewrote the `gh()` shell wrapper in `scripts/git-safety.sh` to dynamically parse CLI arguments, skipping global options (like `-R` or `--repo`) to accurately identify and block `pr merge` in all forms.
- **Review Approval Blocker:** Added a scanner to block `gh pr review` if `--approve` or `-a` is passed, while leaving peer comments (`-c`) and request-changes (`-r`) fully open.
- **Shell Sanitation & Installation Fix:** Updated `scripts/setup.sh` to purge historical duplicate wrapper functions from `~/.bashrc` using a Python-based cleanup routine. This fixes startup shell syntax errors and ensures the new safety wrapper successfully installs and activates.

Closes #13