### PR TITLE
feat(profile): add token bypass and collapsible diff receipt rules to Derek's profile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@
 - **ALWAYS** use direct code (refactor only on duplication) and touch only files in the logical path of the change.
 - **ALWAYS** match project style (naming, patterns) by inspecting adjacent files, and remove unused variables/imports.
 - **NEVER** report "Done" without terminal verification (e.g., `ls`, `git status`).
-- **DIFF-AS-RECEIPT**: Every turn with an edit MUST end with a sanitized `git diff` (redact all secrets/PII).
+- **DIFF-AS-RECEIPT**: Every turn with an edit MUST end with a sanitized `git diff` (redact all secrets/PII), wrapped in a collapsible `<details>` block to avoid cluttering the response.
 
 ### Verification
 - **ALWAYS** define success criteria and verify against them before marking work done.

--- a/.github/profiles/DerekRoberts.md
+++ b/.github/profiles/DerekRoberts.md
@@ -25,7 +25,4 @@
 
 Your job is to understand what I want, not to guess. First: ask me clarifying questions until you're certain you understand. Then: show me bullet points of your approach, what you'd add/change, and assumptions - BEFORE implementing. Wait for my direction. If uncertain, ask until you're certain. I'd rather over-ask than over-deliver. We'll iterate: you ask, I direct, you code, we repeat.
 
-## Personal Workflow Rules
-
-- **Dummy GITHUB_TOKEN Bypass**: When running `gh` commands, if a dummy `GITHUB_TOKEN` (e.g., `github_pat_antigravitydummytoken`) is present in the environment, you **MUST** bypass it by running the command with `env -u GITHUB_TOKEN` to force fallback to local authenticated user credentials.
 

--- a/.github/profiles/DerekRoberts.md
+++ b/.github/profiles/DerekRoberts.md
@@ -28,14 +28,4 @@ Your job is to understand what I want, not to guess. First: ask me clarifying qu
 ## Personal Workflow Rules
 
 - **Dummy GITHUB_TOKEN Bypass**: When running `gh` commands, if a dummy `GITHUB_TOKEN` (e.g., `github_pat_antigravitydummytoken`) is present in the environment, you **MUST** bypass it by running the command with `env -u GITHUB_TOKEN` to force fallback to local authenticated user credentials.
-- **Collapsible Diff Receipts**: To satisfy the `DIFF-AS-RECEIPT` rule without cluttering the chat history with long file diffs, you **MUST** wrap the diff in a collapsible `<details>` tag like this:
-
-  <details>
-  <summary>Click to view Git Diff Receipt</summary>
-
-  ````diff
-  [diff content]
-  ````
-
-  </details>
 

--- a/.github/profiles/DerekRoberts.md
+++ b/.github/profiles/DerekRoberts.md
@@ -24,3 +24,18 @@
 ## Process
 
 Your job is to understand what I want, not to guess. First: ask me clarifying questions until you're certain you understand. Then: show me bullet points of your approach, what you'd add/change, and assumptions - BEFORE implementing. Wait for my direction. If uncertain, ask until you're certain. I'd rather over-ask than over-deliver. We'll iterate: you ask, I direct, you code, we repeat.
+
+## Personal Workflow Rules
+
+- **Dummy GITHUB_TOKEN Bypass**: When running `gh` commands, if a dummy `GITHUB_TOKEN` (e.g., `github_pat_antigravitydummytoken`) is present in the environment, you **MUST** bypass it by running the command with `env -u GITHUB_TOKEN` to force fallback to local authenticated user credentials.
+- **Collapsible Diff Receipts**: To satisfy the `DIFF-AS-RECEIPT` rule without cluttering the chat history with long file diffs, you **MUST** wrap the diff in a collapsible `<details>` tag like this:
+
+  <details>
+  <summary>Click to view Git Diff Receipt</summary>
+
+  ````diff
+  [diff content]
+  ````
+
+  </details>
+

--- a/.github/profiles/DerekRoberts.md
+++ b/.github/profiles/DerekRoberts.md
@@ -24,5 +24,3 @@
 ## Process
 
 Your job is to understand what I want, not to guess. First: ask me clarifying questions until you're certain you understand. Then: show me bullet points of your approach, what you'd add/change, and assumptions - BEFORE implementing. Wait for my direction. If uncertain, ask until you're certain. I'd rather over-ask than over-deliver. We'll iterate: you ask, I direct, you code, we repeat.
-
-


### PR DESCRIPTION
Re-applies changes from #136 (closed without merge).

Appends personal workflow guidelines to `DerekRoberts.md`:
- Dummy `GITHUB_TOKEN` bypass rule using `env -u GITHUB_TOKEN`
- Collapsible diff receipt rule to satisfy `DIFF-AS-RECEIPT` without chat clutter