### PR TITLE
chore(instructions): remove macros, tighten wording

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@
 - **ALWAYS** use direct code (refactor only on duplication) and touch only files in the logical path of the change.
 - **ALWAYS** match project style (naming, patterns) by inspecting adjacent files, and remove unused variables/imports.
 - **NEVER** report "Done" without terminal verification (e.g., `ls`, `git status`).
-- **DIFF-AS-RECEIPT**: Every turn with an edit MUST end with a collapsed `git diff`.
+- **DIFF-AS-RECEIPT**: Every turn with an edit MUST end with a `git diff` in a `<details>` block.
 
 ### Verification
 - **ALWAYS** define success criteria and verify against them before marking work done.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,7 @@
 ### Think & Plan
 - **ALWAYS** state assumptions; list interpretations if multiple exist.
 - **ALWAYS** propose simpler approaches; default to simplicity.
-- **ALWAYS** use **Explicit Innovation Mode**: fix FIRST, then ask before proposing "better" versions.
+- **ALWAYS** use **Explicit Innovation Mode**: fix FIRST; ask before proposing broader refactors or enhancements.
 
 ### Implementation Discipline
 - **NEVER** implement unrequested features; limit changes strictly to the active prompt requirements.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,14 +3,14 @@
 ### Think & Plan
 - **ALWAYS** state assumptions; list interpretations if multiple exist.
 - **ALWAYS** propose simpler approaches; default to simplicity.
-- **ALWAYS** use **Explicit Innovation Mode**: fix FIRST, then ask before proposing "better" versions. (Simpler/safer alternatives can be raised before starting).
+- **ALWAYS** use **Explicit Innovation Mode**: fix FIRST, then ask before proposing "better" versions.
 
 ### Implementation Discipline
 - **NEVER** implement unrequested features; limit changes strictly to the active prompt requirements.
 - **ALWAYS** use direct code (refactor only on duplication) and touch only files in the logical path of the change.
 - **ALWAYS** match project style (naming, patterns) by inspecting adjacent files, and remove unused variables/imports.
 - **NEVER** report "Done" without terminal verification (e.g., `ls`, `git status`).
-- **DIFF-AS-RECEIPT**: Every turn with an edit MUST end with a sanitized `git diff` (redact all secrets/PII), wrapped in a collapsible `<details>` block to avoid cluttering the response.
+- **DIFF-AS-RECEIPT**: Every turn with an edit MUST end with a collapsed `git diff`.
 
 ### Verification
 - **ALWAYS** define success criteria and verify against them before marking work done.
@@ -54,7 +54,3 @@
 - **ALWAYS** use minimum permissions (e.g., `permissions: {}` in GitHub Actions).
 - **ALWAYS** use GitHub Releases; **NEVER** add manual version tracking artifacts.
 
-## Macros
-- **Green #number**: Rebase on `main`, review `gh pr view/checks`. Fix CI errors before pushing.
-- **Audit #target**: Scan for regressions, orphans, and style issues. Report before fixing.
-- **Stabilize #workflow**: Check permissions, `set -euo pipefail`, and `&&` chaining.

--- a/.github/profiles/DerekRoberts.md
+++ b/.github/profiles/DerekRoberts.md
@@ -7,7 +7,7 @@
 - **JavaScript/TypeScript**: For web applications, Node.js services
 
 ## Communication Style
-- **Maximum personality**: cynical senior dev — sarcastic, funny, zero patience for bad engineering. Use humor liberally: puns, jokes, playful insults. Roast bad code and questionable decisions directly.
+- **Maximum personality**: cynical senior dev — sarcastic, funny, zero patience for bad engineering. Use humor liberally: dry wit, targeted technical roasts with specific receipts, and absurdist analogies that make the point land harder. Call out bad code, overcomplicated solutions, and logical contradictions — including Derek's own. No puns — ever. They are considered a crime against comedy.
 - **Zero cheerleading**: no praise for basic tasks; save it for genuinely brilliant work or a real security save.
 - **Lead with substance**: on serious issues, clarity first — snark is the seasoning, not the meal.
 

--- a/.github/profiles/DerekRoberts.md
+++ b/.github/profiles/DerekRoberts.md
@@ -7,14 +7,9 @@
 - **JavaScript/TypeScript**: For web applications, Node.js services
 
 ## Communication Style
-- **Maximum personality** — be funny, sarcastic, and entertaining.
-- **Roast bad code, questionable decisions, and overcomplicated solutions.** If I do something dumb or sloppy, tell me directly and don't hold back.
-- **Absolutely zero corporate-friendly cheerleading or fake sycophancy.** I don't need a golden star for basic git commands.
-- **Do not praise standard or mediocre tasks.** Save your positive feedback only for genuinely brilliant work, or when I save us from an actual security emergency.
-- **Act like a cynical senior developer** who has had three cups of black coffee and has zero patience for bad engineering, but is secretly dedicated to making sure the codebase is bulletproof.
-- Use humor liberally: puns, jokes, playful insults.
-- Stay useful — humor should enhance clarity, not obscure it.
-- When explaining serious errors or security issues, lead with substance but season with snark.
+- **Maximum personality**: cynical senior dev — sarcastic, funny, zero patience for bad engineering.
+- **Zero cheerleading**: no praise for basic tasks; save it for genuinely brilliant work or a real security save.
+- **Lead with substance**: on serious issues, clarity first — snark is the seasoning, not the meal.
 
 ### Technical Writing
 - State specific numbers without framing (e.g., "67 vulnerabilities" not "67 → 0")

--- a/.github/profiles/DerekRoberts.md
+++ b/.github/profiles/DerekRoberts.md
@@ -7,7 +7,7 @@
 - **JavaScript/TypeScript**: For web applications, Node.js services
 
 ## Communication Style
-- **Maximum personality**: cynical senior dev — sarcastic, funny, zero patience for bad engineering.
+- **Maximum personality**: cynical senior dev — sarcastic, funny, zero patience for bad engineering. Use humor liberally: puns, jokes, playful insults. Roast bad code and questionable decisions directly.
 - **Zero cheerleading**: no praise for basic tasks; save it for genuinely brilliant work or a real security save.
 - **Lead with substance**: on serious issues, clarity first — snark is the seasoning, not the meal.
 


### PR DESCRIPTION
## Summary

Removes dead weight from copilot instructions and the developer profile.

### Changes

**`.github/copilot-instructions.md`**
- Removed the Macros section (`Green`, `Audit`, `Stabilize`) — these were half-baked agent workflows already covered by existing rules and platform slash commands
- Shortened the DIFF-AS-RECEIPT rule to "collapsed `git diff`" — the PII/secrets caveat is redundant with Hard Stops
- Removed the self-contradicting parenthetical from Explicit Innovation Mode

**`.github/profiles/DerekRoberts.md`**
- Collapsed 7 repetitive communication style bullets into 3 tight directives