### PR TITLE
fix(setup): support piped installer and remove profile autodetection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you want to maintain your own personality settings or technical preferences w
    ````bash
    ./setup.sh [GitHubID]
    ````
-   *If you omit the ID, the script attempts to resolve it automatically via the GitHub CLI, and falls back to only bundling the shared standards if not found.*
+   *If you omit the ID, the script only bundles the shared standards by default.*
 
 ---
 

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -20,13 +20,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # 1. Capture Arguments
 OUTPUT_FILE="$HOME/.config/Code/User/prompts/global.instructions.md"
-GH_ID_FALLBACK=""
-if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
-    GH_ID_FALLBACK=$(gh api user --jq '.login' 2>/dev/null || true)
-    GH_ID_FALLBACK=$(echo "$GH_ID_FALLBACK" | tr -d '"{}[] ')
-fi
-
-PROFILE_NAME="${1:-$GH_ID_FALLBACK}"
+PROFILE_NAME="${1:-}"
 
 # Paths
 GLOBAL_FILE="${REPO_ROOT}/.github/copilot-instructions.md"

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-}")" && pwd)
 
 # Detect if running via curl | bash (no local setup assets available)
 if [[ ! -f "$SCRIPT_DIR/scripts/git-safety.sh" ]]; then


### PR DESCRIPTION
## Overview
This PR fixes two issues with the installer and cleans up the documentation:
1. **Piped Installer Crash:** Fixed the unbound variable error in `setup.sh` when piped via `curl` by fallback-expanding `BASH_SOURCE[0]`.
2. **Profile Autodetection Crash:** Removed the `gh` CLI username autodetection fallback in `scripts/bundle.sh` to prevent fatal setup crashes for users whose GitHub handles don't have matching profile files in the repository.
3. **README Documentation:** Updated `README.md` to reflect that profile loading is now explicit and no longer uses background CLI autodetection.

## Changes
- **setup.sh:** Changed `BASH_SOURCE[0]` to `${BASH_SOURCE[0]:-}` to handle standard input piping.
- **scripts/bundle.sh:** Removed the `GH_ID_FALLBACK` block that queried the GitHub API. Profiles must now be explicitly requested as arguments (e.g., `./setup.sh DerekRoberts`), which defaults to a clean, shared instructions bundle for all other users.
- **README.md:** Updated instructions to clarify that omitting the profile ID argument defaults to bundling the shared standards only.