### PR TITLE
feat(security): block gh commenting and reviewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ When running the setup script, transparent shell safety wrappers intercept the f
 | **GitHub CLI** | `pr merge` | Prevents AI from bypassing human review to merge its own code. |
 | **GitHub CLI** | `repo delete` | Catastrophic failure prevention. AI should never have the power to delete repositories. |
 | **GitHub CLI** | `secret` | Prevents AI from viewing or modifying organizational/repository secrets. |
+| **GitHub CLI** | `issue (write)` | Prevents AI from creating, commenting on, or editing issues under the user's name. |
+| **GitHub CLI** | `pr (write)` | Prevents AI from creating, commenting on, reviewing, or closing PRs under the user's name. |
 | **npm / npx** | `--legacy-peer-deps` | Prevents bypassing peer dependency resolution, ensuring clean package management. |
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ When running the setup script, transparent shell safety wrappers intercept the f
 | **GitHub CLI** | `pr merge` | Prevents AI from bypassing human review to merge its own code. |
 | **GitHub CLI** | `repo delete` | Catastrophic failure prevention. AI should never have the power to delete repositories. |
 | **GitHub CLI** | `secret` | Prevents AI from viewing or modifying organizational/repository secrets. |
-| **GitHub CLI** | `issue (write)` | Prevents AI from creating, commenting on, or editing issues under the user's name. |
-| **GitHub CLI** | `pr (write)` | Prevents AI from creating, commenting on, reviewing, or closing PRs under the user's name. |
+| **GitHub CLI** | `issue comment` | Prevents AI from commenting on issues under the user's name (impersonation). |
+| **GitHub CLI** | `pr comment/review` | Prevents AI from commenting on or reviewing Pull Requests under the user's name. |
 | **npm / npx** | `--legacy-peer-deps` | Prevents bypassing peer dependency resolution, ensuring clean package management. |
 
 > [!NOTE]

--- a/scripts/git-safety.sh
+++ b/scripts/git-safety.sh
@@ -167,17 +167,17 @@ gh() {
             echo "         HALT immediately." >&2
             return 1
         elif [[ "$cmd" == "issue" ]]; then
-            if [[ "$sub" == "create" || "$sub" == "comment" || "$sub" == "edit" || "$sub" == "close" || "$sub" == "reopen" || "$sub" == "delete" ]]; then
-                echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from creating, editing, commenting on, or closing issues." >&2
-                echo "         Running write commands via 'gh issue' posts content using the USER's identity, which violates impersonation policies." >&2
-                echo "         HALT immediately. Output the issue/comment content to the chat for the USER to post manually." >&2
+            if [[ "$sub" == "comment" ]]; then
+                echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from commenting on issues." >&2
+                echo "         Posting comments simulates human discussion and violates impersonation policies." >&2
+                echo "         HALT immediately. Output the comment content to the chat for the USER to post manually." >&2
                 return 1
             fi
         elif [[ "$cmd" == "pr" ]]; then
-            if [[ "$sub" == "create" || "$sub" == "comment" || "$sub" == "close" || "$sub" == "reopen" || "$sub" == "review" ]]; then
-                echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from creating, commenting on, reviewing, or closing Pull Requests." >&2
-                echo "         Running write commands via 'gh pr' posts content using the USER's identity, which violates impersonation policies." >&2
-                echo "         HALT immediately. Output the details/commands to the chat for the USER to execute manually." >&2
+            if [[ "$sub" == "comment" || "$sub" == "review" ]]; then
+                echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from commenting on or reviewing Pull Requests." >&2
+                echo "         Posting comments or reviews simulates human discussion/review and violates impersonation policies." >&2
+                echo "         HALT immediately. Output the details to the chat for the USER to post manually." >&2
                 return 1
             elif [[ "$sub" == "merge" ]]; then
                 echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from merging Pull Requests." >&2

--- a/scripts/git-safety.sh
+++ b/scripts/git-safety.sh
@@ -166,22 +166,25 @@ gh() {
             echo "         Secret management must be handled directly by the USER." >&2
             echo "         HALT immediately." >&2
             return 1
+        elif [[ "$cmd" == "issue" ]]; then
+            if [[ "$sub" == "create" || "$sub" == "comment" || "$sub" == "edit" || "$sub" == "close" || "$sub" == "reopen" || "$sub" == "delete" ]]; then
+                echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from creating, editing, commenting on, or closing issues." >&2
+                echo "         Running write commands via 'gh issue' posts content using the USER's identity, which violates impersonation policies." >&2
+                echo "         HALT immediately. Output the issue/comment content to the chat for the USER to post manually." >&2
+                return 1
+            fi
         elif [[ "$cmd" == "pr" ]]; then
-            if [[ "$sub" == "merge" ]]; then
+            if [[ "$sub" == "create" || "$sub" == "comment" || "$sub" == "close" || "$sub" == "reopen" || "$sub" == "review" ]]; then
+                echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from creating, commenting on, reviewing, or closing Pull Requests." >&2
+                echo "         Running write commands via 'gh pr' posts content using the USER's identity, which violates impersonation policies." >&2
+                echo "         HALT immediately. Output the details/commands to the chat for the USER to execute manually." >&2
+                return 1
+            elif [[ "$sub" == "merge" ]]; then
                 echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from merging Pull Requests." >&2
                 echo "         Under bcgov/copilot-instructions policy, all merges must be reviewed and executed manually by the USER." >&2
                 echo "         Do NOT attempt to bypass this block using absolute paths, alternate flags, or command overrides." >&2
                 echo "         HALT immediately and report to the user." >&2
                 return 1
-            elif [[ "$sub" == "review" ]]; then
-                for arg in "$@"; do
-                    if [[ "$arg" == "--approve" || "$arg" == "-a" ]]; then
-                        echo "BLOCKED: AI Agents are STRICTLY FORBIDDEN from approving Pull Requests." >&2
-                        echo "         Self-approving or bypass-approving is a direct violation of repository security guardrails." >&2
-                        echo "         HALT immediately and request manual approval from the USER." >&2
-                        return 1
-                    fi
-                done
             fi
         fi
     fi


### PR DESCRIPTION
Implements safety wrapper intercepts in `scripts/git-safety.sh` to block AI agents from executing commenting or reviewing commands on GitHub Issues (`gh issue comment`) and Pull Requests (`gh pr comment`, `gh pr review`). This allows AI assistants to still create PRs and issues (`gh pr create`, `gh issue create`) while preventing them from impersonating developers or participating in discussion/peer review threads on their behalf.