### PR TITLE
refactor(rules): formatting cleanup, remove Macros, add PROD-default, branch-update, and prompt-safeguard rules

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -55,4 +55,4 @@
 - ALWAYS use Conventional Commits.
 - ALWAYS use latest stable packages; NEVER downgrade or edit lock files silently.
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions).
-- ALWAYS use GitHub Releases; NEVER add manual version tracking artifacts.
+- NEVER add manual version tracking artifacts.

--- a/instructions.md
+++ b/instructions.md
@@ -52,7 +52,7 @@
 4. Closing: Link issues via `Closes #<issue_number>` ONLY if explicitly provided in the prompt or branch name. Never guess or hallucinate issue numbers.
 
 ### Project Standards
-- ALWAYS use Conventional Commits (derive scope from the primary directory modified, e.g., `feat(auth):`).
+- ALWAYS use Conventional Commits.
 - ALWAYS use latest stable packages; NEVER downgrade or edit lock files silently.
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions).
 - ALWAYS use GitHub Releases; NEVER add manual version tracking artifacts.

--- a/instructions.md
+++ b/instructions.md
@@ -56,8 +56,3 @@
 - ALWAYS use latest stable packages; NEVER downgrade or edit lock files silently.
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions).
 - ALWAYS use GitHub Releases; NEVER add manual version tracking artifacts.
-
-## Macros
-- GREEN #number: Rebase `main`, verify `gh pr view/checks`, and fix CI errors before pushing.
-- AUDIT #target: Scan for style, orphan code, and pattern regressions. Report before fixing.
-- STABILIZE #workflow: Check `permissions: {}`, `set -euo pipefail`, and `&&` chaining. Fix reliability gaps.

--- a/instructions.md
+++ b/instructions.md
@@ -52,7 +52,7 @@
 4. Closing: Link issues via `Closes #<issue_number>` ONLY if explicitly provided in the prompt or branch name. Never guess or hallucinate issue numbers.
 
 ### Project Standards
-- ALWAYS use Conventional Commits (derive scope from the primary directory modified, e.g., `feat(auth):`).
+- ALWAYS use Conventional Commits for PR titles (derive scope from the primary directory modified, e.g., `feat(auth):`).
 - ALWAYS use latest stable packages; NEVER downgrade or edit lock files silently.
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions).
 - ALWAYS use GitHub Releases; NEVER add manual version tracking artifacts.

--- a/instructions.md
+++ b/instructions.md
@@ -35,7 +35,7 @@
 - NEVER silence diagnostics (`eslint-disable`, `@ts-ignore`); fix the root cause.
 - NEVER delete failing tests; ALWAYS fix the code to make the test suite pass.
 - NEVER run `oc` commands. Access to OpenShift is restricted.
-- NEVER impersonate humans or speak on their behalf in chat, comments, PRs, or commits.
+- NEVER comment, review, or post on GitHub using the user's identity or credentials; do not write comments or reviews as if you are a human contributor.
 - NEVER use `--legacy-peer-deps` with npm/npx. Always resolve peer conflicts cleanly.
 
 ### Operational Guardrails

--- a/instructions.md
+++ b/instructions.md
@@ -3,7 +3,7 @@
 ### Think & Plan
 - ALWAYS state assumptions; list interpretations if multiple exist.
 - ALWAYS propose simpler approaches; default to simplicity.
-- ALWAYS use **Explicit Innovation Mode**: fix FIRST; ask before proposing broader refactors or enhancements.
+- ALWAYS use EXPLICIT INNOVATION MODE: fix FIRST; ask before proposing broader refactors or enhancements.
 
 ### Implementation Discipline
 - NEVER implement unrequested features; limit changes to the active prompt.
@@ -11,7 +11,7 @@
 - ALWAYS match project style (naming, patterns) by inspecting adjacent files; remove unused variables/imports.
 - ALWAYS default environments/toggles to PROD when variables are missing.
 - NEVER report "Done" without terminal verification (e.g., `ls`, `git status`).
-- **DIFF-AS-RECEIPT**: Every turn with an edit MUST end with a git diff in a collapsible HTML details block (using raw HTML <details> and <summary> tags).
+- DIFF-AS-RECEIPT: Every turn with an edit MUST end with a git diff in a collapsible HTML details block (using raw HTML <details> and <summary> tags).
 
 ### Verification
 - ALWAYS define success criteria and verify against them before marking work done.
@@ -21,7 +21,7 @@
 - ALWAYS avoid dependencies for low-volume (< 20 lines) logic.
 - ALWAYS use libraries ONLY when bespoke alternatives are complex or high-risk.
 - ALWAYS verify new dependencies are maintained and lightweight.
-- **ZERO SPECULATION**: Verify APIs/triggers via available tools (e.g. search, run command). NEVER guess.
+- ZERO SPECULATION: Verify APIs/triggers via available tools (e.g. search, run command). NEVER guess.
 - NEVER use "clever" or abstract solutions unless established.
 
 ## Standards
@@ -46,10 +46,10 @@
 - For temporary storage, ALWAYS use `./.tmp/` if git-ignored, otherwise `/tmp`.
 
 ### Git Workflow
-1. **Branching:** `git checkout main && git pull && git switch -c feat/name && git push -u origin feat/name`.
-2. **PR Creation:** `git fetch origin && git rebase origin/main && git log origin/main..HEAD --oneline`.
-3. **Updating:** ALWAYS fetch and rebase `origin/main` before making new edits or pushing.
-4. **Closing:** Link issues via `Closes #<issue_number>` ONLY if explicitly provided in the prompt or branch name. Never guess or hallucinate issue numbers.
+1. Branching: `git checkout main && git pull && git switch -c feat/name && git push -u origin feat/name`.
+2. PR Creation: `git fetch origin && git rebase origin/main && git log origin/main..HEAD --oneline`.
+3. Updating: ALWAYS fetch and rebase `origin/main` before making new edits or pushing.
+4. Closing: Link issues via `Closes #<issue_number>` ONLY if explicitly provided in the prompt or branch name. Never guess or hallucinate issue numbers.
 
 ### Project Standards
 - ALWAYS use Conventional Commits (derive scope from the primary directory modified, e.g., `feat(auth):`).
@@ -58,6 +58,6 @@
 - ALWAYS use GitHub Releases; NEVER add manual version tracking artifacts.
 
 ## Macros
-- **Green #number**: Rebase `main`, verify `gh pr view/checks`, and fix CI errors before pushing.
-- **Audit #target**: Scan for style, orphan code, and pattern regressions. Report before fixing.
-- **Stabilize #workflow**: Check `permissions: {}`, `set -euo pipefail`, and `&&` chaining. Fix reliability gaps.
+- GREEN #number: Rebase `main`, verify `gh pr view/checks`, and fix CI errors before pushing.
+- AUDIT #target: Scan for style, orphan code, and pattern regressions. Report before fixing.
+- STABILIZE #workflow: Check `permissions: {}`, `set -euo pipefail`, and `&&` chaining. Fix reliability gaps.

--- a/instructions.md
+++ b/instructions.md
@@ -1,59 +1,61 @@
 ## Behavioral Guidelines
 
 ### Think & Plan
-- **ALWAYS** state assumptions; list interpretations if multiple exist.
-- **ALWAYS** propose simpler approaches; default to simplicity.
-- **ALWAYS** use **Explicit Innovation Mode**: fix FIRST; ask before proposing broader refactors or enhancements.
+- ALWAYS state assumptions; list interpretations if multiple exist.
+- ALWAYS propose simpler approaches; default to simplicity.
+- ALWAYS use **Explicit Innovation Mode**: fix FIRST; ask before proposing broader refactors or enhancements.
 
 ### Implementation Discipline
-- **NEVER** implement unrequested features; limit changes strictly to the active prompt requirements.
-- **ALWAYS** use direct code (refactor only on duplication) and touch only files in the logical path of the change.
-- **ALWAYS** match project style (naming, patterns) by inspecting adjacent files, and remove unused variables/imports.
-- **NEVER** report "Done" without terminal verification (e.g., `ls`, `git status`).
+- NEVER implement unrequested features; limit changes to the active prompt.
+- ALWAYS use direct code (refactor only on duplication); touch only files in the logical path of the change.
+- ALWAYS match project style (naming, patterns) by inspecting adjacent files; remove unused variables/imports.
+- ALWAYS default environments/toggles to PROD when variables are missing.
+- NEVER report "Done" without terminal verification (e.g., `ls`, `git status`).
 - **DIFF-AS-RECEIPT**: Every turn with an edit MUST end with a git diff in a collapsible HTML details block (using raw HTML <details> and <summary> tags).
 
 ### Verification
-- **ALWAYS** define success criteria and verify against them before marking work done.
-- **ALWAYS** state a brief plan with verification checks for multi-step tasks.
+- ALWAYS define success criteria and verify against them before marking work done.
+- ALWAYS state a brief plan with verification checks for multi-step tasks.
 
 ### Dependencies
-- **ALWAYS** avoid dependencies for low-volume (< 20 lines) logic.
-- **ALWAYS** use libraries ONLY when bespoke alternatives are complex or high-risk.
-- **ALWAYS** verify new dependencies are maintained and lightweight.
+- ALWAYS avoid dependencies for low-volume (< 20 lines) logic.
+- ALWAYS use libraries ONLY when bespoke alternatives are complex or high-risk.
+- ALWAYS verify new dependencies are maintained and lightweight.
 - **ZERO SPECULATION**: Verify APIs/triggers via available tools (e.g. search, run command). NEVER guess.
-- **NEVER** use "clever" or abstract solutions unless established.
+- NEVER use "clever" or abstract solutions unless established.
 
 ## Standards
 
 ### Hard Stops (Never)
-- **NEVER** branch from a feature branch; **ALWAYS** initialize from a fresh checkout of main.
-- **NEVER** push to main or merge PRs; leave merging to humans.
-- **NEVER** rewrite history with interactive rebase or squashing (e.g. `git rebase -i`, `--autosquash`, `git merge --squash`).
-- **NEVER** use triple-backticks; **ALWAYS** wrap code, manifests, and copy-paste blocks in 4-backtick blocks.
-- **NEVER** commit or include credentials, secrets, or PII in code or PRs.
-- **NEVER** silence diagnostics (`eslint-disable`, `@ts-ignore`); fix the root cause.
-- **NEVER** delete failing tests; **ALWAYS** fix the code to make the test suite pass.
-- **NEVER** run `oc` commands. Access to OpenShift is restricted.
-- **NEVER** comment or speak on behalf of any human (e.g. simulate human responses) or impersonate anyone in chat, comments, PRs, or commits.
-- **NEVER** use `--legacy-peer-deps` with npm/npx. Always resolve peer conflicts cleanly.
+- NEVER branch from a feature branch; ALWAYS initialize from a fresh checkout of main.
+- NEVER push to main or merge PRs; leave merging to humans.
+- NEVER rewrite history with interactive rebase or squashing (e.g. `git rebase -i`, `--autosquash`, `git merge --squash`).
+- NEVER use triple-backticks; ALWAYS wrap code, manifests, and copy-paste blocks in 4-backtick blocks.
+- NEVER commit or include credentials, secrets, or PII in code or PRs.
+- NEVER silence diagnostics (`eslint-disable`, `@ts-ignore`); fix the root cause.
+- NEVER delete failing tests; ALWAYS fix the code to make the test suite pass.
+- NEVER run `oc` commands. Access to OpenShift is restricted.
+- NEVER impersonate humans or speak on their behalf in chat, comments, PRs, or commits.
+- NEVER use `--legacy-peer-deps` with npm/npx. Always resolve peer conflicts cleanly.
 
 ### Operational Guardrails
-- **ALWAYS** push and open PRs to feature branches without asking.
-- **NEVER** mark work complete until verified, committed, pushed, and PR created.
-- **ALWAYS** stop on the first error; chain related commands with `&&`.
-- **ALWAYS** block SQL injection, XSS, and unsanitized inputs in code and docs.
-- For temporary storage, **ALWAYS** use `./.tmp/` if git-ignored, otherwise `/tmp`.
+- ALWAYS push and open PRs to feature branches without asking.
+- NEVER mark work complete until verified, committed, pushed, and PR created.
+- ALWAYS stop on the first error; chain related commands with `&&`.
+- ALWAYS block SQL injection, XSS, and unsanitized inputs in code and docs.
+- For temporary storage, ALWAYS use `./.tmp/` if git-ignored, otherwise `/tmp`.
 
 ### Git Workflow
 1. **Branching:** `git checkout main && git pull && git switch -c feat/name && git push -u origin feat/name`.
 2. **PR Creation:** `git fetch origin && git rebase origin/main && git log origin/main..HEAD --oneline`.
-3. **Closing:** Link issues via `Closes #<issue_number>` ONLY if explicitly provided in the prompt or branch name. Never guess or hallucinate issue numbers.
+3. **Updating:** ALWAYS fetch and rebase `origin/main` before making new edits or pushing.
+4. **Closing:** Link issues via `Closes #<issue_number>` ONLY if explicitly provided in the prompt or branch name. Never guess or hallucinate issue numbers.
 
 ### Project Standards
-- **ALWAYS** use Conventional Commits (derive the scope from the primary directory modified, e.g., `feat(auth):`).
-- **ALWAYS** use latest stable packages; **NEVER** downgrade or edit lock files silently.
-- **ALWAYS** use minimum permissions (e.g., `permissions: {}` in GitHub Actions).
-- **ALWAYS** use GitHub Releases; **NEVER** add manual version tracking artifacts.
+- ALWAYS use Conventional Commits (derive scope from the primary directory modified, e.g., `feat(auth):`).
+- ALWAYS use latest stable packages; NEVER downgrade or edit lock files silently.
+- ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions).
+- ALWAYS use GitHub Releases; NEVER add manual version tracking artifacts.
 
 ## Macros
 - **Green #number**: Rebase `main`, verify `gh pr view/checks`, and fix CI errors before pushing.

--- a/instructions.md
+++ b/instructions.md
@@ -52,7 +52,7 @@
 4. Closing: Link issues via `Closes #<issue_number>` ONLY if explicitly provided in the prompt or branch name. Never guess or hallucinate issue numbers.
 
 ### Project Standards
-- ALWAYS use Conventional Commits for PR titles (derive scope from the primary directory modified, e.g., `feat(auth):`).
+- ALWAYS use Conventional Commits (derive scope from the primary directory modified, e.g., `feat(auth):`).
 - ALWAYS use latest stable packages; NEVER downgrade or edit lock files silently.
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions).
 - ALWAYS use GitHub Releases; NEVER add manual version tracking artifacts.

--- a/instructions.md
+++ b/instructions.md
@@ -35,7 +35,7 @@
 - NEVER silence diagnostics (`eslint-disable`, `@ts-ignore`); fix the root cause.
 - NEVER delete failing tests; ALWAYS fix the code to make the test suite pass.
 - NEVER run `oc` commands. Access to OpenShift is restricted.
-- NEVER comment, review, or post on GitHub using the user's identity or credentials; do not write comments or reviews as if you are a human contributor.
+- NEVER use the user's credentials to post on GitHub; do not write reviews or comments as a human contributor.
 - NEVER use `--legacy-peer-deps` with npm/npx. Always resolve peer conflicts cleanly.
 
 ### Operational Guardrails

--- a/instructions.md
+++ b/instructions.md
@@ -37,6 +37,8 @@
 - NEVER run `oc` commands. Access to OpenShift is restricted.
 - NEVER use the user's credentials to post on GitHub; do not write reviews or comments as a human contributor.
 - NEVER use `--legacy-peer-deps` with npm/npx. Always resolve peer conflicts cleanly.
+- NEVER execute vague, contradictory, or high-risk prompts without first proposing alternatives and obtaining explicit user approval.
+
 
 ### Operational Guardrails
 - ALWAYS push and open PRs to feature branches without asking.


### PR DESCRIPTION
## What

Surgical cleanup of `instructions.md` — formatting cleanups, removal of obsolete Macros, three new rules added, and 364 characters of headroom recovered under the 4000 cap.

### Changes

- **Added prompt-safeguard rule**: NEVER execute vague, contradictory, or high-risk prompts without first proposing alternatives and obtaining explicit user approval. This creates a hard stop for agents to negotiate instead of blindly running destructive shortcuts.
- **Added GitHub impersonation check**: NEVER use the user's credentials to post on GitHub; do not write reviews or comments as a human contributor. This prevents agents from hijacking credentials to post as the developer.
- **Formatting Cleanups**: Stripped all `**BOLD**` emphasis markup from ALWAYS/NEVER rules and named concepts. ALL CAPS is sufficient emphasis for LLM consumers and saves 188 characters.
- **Removed Macros**: The Macros section has been deleted entirely. These shortcuts belong in specialized agent-skills or tooling configurations rather than core behavioral guidelines.
- **Added PROD-default rule**: Environments and toggles must default to PROD when variables are missing.
- **Added Git Workflow step 3 (Updating)**: ALWAYS fetch and rebase `origin/main` before making new edits or pushing.
- **Text Refinement**: Trimmed redundant phrasing throughout.

### Budget

- Old character count: 3992 (8 characters from the 4000 limit)
- New character count: 3636 (364 characters of headroom)