### PR TITLE
docs(readme): focus primary instructions on global setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,17 @@ The canonical text lives in **[instructions.md](instructions.md)** at the repo r
 
 ## Use this file
 
-**Project-level:** copy the root file into your repo as `.github/copilot-instructions.md` (which GitHub Copilot and other IDE tools scan for):
+**Global-level (VS Code):** Copy the root file into your global prompts directory:
 
 ````bash
+mkdir -p ~/.config/Code/User/prompts
 curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md \
-  -o .github/copilot-instructions.md
+  -o ~/.config/Code/User/prompts/global.instructions.md
 ````
 
-**Org-level:** configure custom agent instructions from the [raw file](https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md) or paste its contents into org settings.
+*(Note: You can also copy these instructions to individual repositories at `.github/copilot-instructions.md` for project-level customization).*
+
+**Org-level:** Configure custom agent instructions from the [raw file](https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md) or paste its contents into org settings.
 
 ## Agent guardrails (enforcement)
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Guidelines for AI-assisted development, written with the intent of becoming a pr
 
 The canonical text lives in **[instructions.md](instructions.md)** at the repo root — visible, reviewable, and copy-ready.
 
-> [!IMPORTANT]
-> GitHub enforces a **4,000 character limit** for organizational Custom Instructions. Keep [instructions.md](instructions.md) under that limit (CI validates on every PR).
-
 ## Use this file
 
-**Global-level (Linux/macOS/WSL):** Copy the root file into your global Copilot instructions folder:
+You can apply these instructions at different levels depending on your setup:
+
+### Global-level (Linux/macOS/WSL)
+Copy the root file into your global Copilot instructions folder to apply these guidelines across all your local sessions:
 
 ````bash
 mkdir -p ~/.copilot/instructions
@@ -19,9 +19,19 @@ curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instr
   -o ~/.copilot/instructions/instructions.md
 ````
 
-*(Note: You can also copy these instructions to individual repositories at `.github/copilot-instructions.md` for project-level customization).*
+### Project-level (Repository)
+Copy the root file into individual repositories as `.github/copilot-instructions.md` for project-specific customization:
 
-**Org-level:** Configure custom agent instructions from the [raw file](https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md) or paste its contents into org settings.
+````bash
+curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md \
+  -o .github/copilot-instructions.md
+````
+
+### Org-level (Organization)
+Configure custom agent instructions for your GitHub Organization by pointing to the [raw file](https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md) or pasting its contents directly into your organization's settings.
+
+> [!IMPORTANT]
+> GitHub enforces a **4,000 character limit** for organizational Custom Instructions. Keep [instructions.md](instructions.md) under that limit (CI validates on every PR).
 
 ## Agent guardrails (enforcement)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Guidelines for AI-assisted development, written with the intent of becoming a pr
 
 > **Not an official BC Government publication.** Content here reflects community work in progress. It does not speak for, bind, or represent the Province of British Columbia. We welcome contributors so this can grow into something genuinely useful for public-sector developers in BC.
 
-The canonical text lives in **[instructions.md](instructions.md)** at the repo root. It is visible, reviewable, and copy-ready.
+The canonical text lives in **[instructions.md](instructions.md)** at the repo root.
 
 ## Use this file
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ The canonical text lives in **[instructions.md](instructions.md)** at the repo r
 
 ## Use this file
 
-**Global-level (VS Code - Linux/macOS):** Copy the root file into your global prompts directory:
+**Global-level (VS Code - Linux/macOS):** Copy the root file into your global prompts or user-level Copilot directory:
 
 ````bash
+# Option 1: VS Code Custom Instructions (Default UI Path)
 # For Linux
 mkdir -p ~/.config/Code/User/prompts
 curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md \
@@ -23,6 +24,11 @@ curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instr
 mkdir -p ~/Library/Application\ Support/Code/User/prompts
 curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md \
   -o ~/Library/Application\ Support/Code/User/prompts/global.instructions.md
+
+# Option 2: General User-level Copilot directory
+mkdir -p ~/.copilot
+curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md \
+  -o ~/.copilot/copilot-instructions.md
 ````
 
 **Global-level (VS Code - Windows):** Copy the root file using PowerShell:

--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ curl -fsSL https://raw.githubusercontent.com/bcgov/agent-guardrails/main/setup.s
 
 ## Contributing
 
-We want this to become something teams across BC can actually adopt. Open a PR to improve [instructions.md](instructions.md) — keep it under 4,000 characters, stay concrete, and explain the *why* in the PR description when a rule is non-obvious.
+We want this to become something teams across BC can actually adopt. Open a PR to improve [instructions.md](instructions.md). Keep it under 4,000 characters, stay concrete, and explain the *why* in the PR description when a rule is non-obvious.
 

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ We want this to become something teams across BC can actually adopt. Open a PR t
 
 ## Attribution
 
-Behavioral guidelines adapted from [CLAUDE.md](https://github.com/forrestchang/andrej-karpathy-skills/blob/main/CLAUDE.md) by Forrest Chang. Guardrails and git setup moved to [bcgov/agent-guardrails](https://github.com/bcgov/agent-guardrails).
+Guardrails and git setup moved to [bcgov/agent-guardrails](https://github.com/bcgov/agent-guardrails).

--- a/README.md
+++ b/README.md
@@ -11,32 +11,20 @@ The canonical text lives in **[instructions.md](instructions.md)** at the repo r
 
 ## Use this file
 
-**Global-level (VS Code - Linux/macOS):** Copy the root file into your global prompts or user-level Copilot directory:
+**Global-level (Linux/macOS):** Copy the root file into your global Copilot instructions folder:
 
 ````bash
-# Option 1: VS Code Custom Instructions (Default UI Path)
-# For Linux
-mkdir -p ~/.config/Code/User/prompts
+mkdir -p ~/.copilot/instructions
 curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md \
-  -o ~/.config/Code/User/prompts/global.instructions.md
-
-# For macOS
-mkdir -p ~/Library/Application\ Support/Code/User/prompts
-curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md \
-  -o ~/Library/Application\ Support/Code/User/prompts/global.instructions.md
-
-# Option 2: General User-level Copilot directory
-mkdir -p ~/.copilot
-curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md \
-  -o ~/.copilot/copilot-instructions.md
+  -o ~/.copilot/instructions/instructions.md
 ````
 
-**Global-level (VS Code - Windows):** Copy the root file using PowerShell:
+**Global-level (Windows):** Copy the root file using PowerShell:
 
 ````powershell
-New-Item -ItemType Directory -Force -Path "$env:APPDATA\Code\User\prompts"
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.copilot\instructions"
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md" `
-  -OutFile "$env:APPDATA\Code\User\prompts\global.instructions.md"
+  -OutFile "$env:USERPROFILE\.copilot\instructions\instructions.md"
 ````
 
 *(Note: You can also copy these instructions to individual repositories at `.github/copilot-instructions.md` for project-level customization).*

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instr
 ````
 
 ### Org-level (Organization)
-Configure custom agent instructions for your GitHub Organization by pointing to the [raw file](https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md) or pasting its contents directly into your organization's settings.
+Configure custom agent instructions for your GitHub Organization by copying the contents of the [raw file](https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md) and pasting them directly into your organization's settings.
 
 > [!IMPORTANT]
 > GitHub enforces a **4,000 character limit** for organizational Custom Instructions. Keep [instructions.md](instructions.md) under that limit (CI validates on every PR).

--- a/README.md
+++ b/README.md
@@ -11,20 +11,12 @@ The canonical text lives in **[instructions.md](instructions.md)** at the repo r
 
 ## Use this file
 
-**Global-level (Linux/macOS):** Copy the root file into your global Copilot instructions folder:
+**Global-level (Linux/macOS/WSL):** Copy the root file into your global Copilot instructions folder:
 
 ````bash
 mkdir -p ~/.copilot/instructions
 curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md \
   -o ~/.copilot/instructions/instructions.md
-````
-
-**Global-level (Windows):** Copy the root file using PowerShell:
-
-````powershell
-New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.copilot\instructions"
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md" `
-  -OutFile "$env:USERPROFILE\.copilot\instructions\instructions.md"
 ````
 
 *(Note: You can also copy these instructions to individual repositories at `.github/copilot-instructions.md` for project-level customization).*

--- a/README.md
+++ b/README.md
@@ -45,6 +45,3 @@ curl -fsSL https://raw.githubusercontent.com/bcgov/agent-guardrails/main/setup.s
 
 We want this to become something teams across BC can actually adopt. Open a PR to improve [instructions.md](instructions.md) — keep it under 4,000 characters, stay concrete, and explain the *why* in the PR description when a rule is non-obvious.
 
-## Attribution
-
-Guardrails and git setup moved to [bcgov/agent-guardrails](https://github.com/bcgov/agent-guardrails).

--- a/README.md
+++ b/README.md
@@ -11,12 +11,26 @@ The canonical text lives in **[instructions.md](instructions.md)** at the repo r
 
 ## Use this file
 
-**Global-level (VS Code):** Copy the root file into your global prompts directory:
+**Global-level (VS Code - Linux/macOS):** Copy the root file into your global prompts directory:
 
 ````bash
+# For Linux
 mkdir -p ~/.config/Code/User/prompts
 curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md \
   -o ~/.config/Code/User/prompts/global.instructions.md
+
+# For macOS
+mkdir -p ~/Library/Application\ Support/Code/User/prompts
+curl -fsSL https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md \
+  -o ~/Library/Application\ Support/Code/User/prompts/global.instructions.md
+````
+
+**Global-level (VS Code - Windows):** Copy the root file using PowerShell:
+
+````powershell
+New-Item -ItemType Directory -Force -Path "$env:APPDATA\Code\User\prompts"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/bcgov/agent-instructions/main/instructions.md" `
+  -OutFile "$env:APPDATA\Code\User\prompts\global.instructions.md"
 ````
 
 *(Note: You can also copy these instructions to individual repositories at `.github/copilot-instructions.md` for project-level customization).*

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Guidelines for AI-assisted development, written with the intent of becoming a pr
 
 > **Not an official BC Government publication.** Content here reflects community work in progress. It does not speak for, bind, or represent the Province of British Columbia. We welcome contributors so this can grow into something genuinely useful for public-sector developers in BC.
 
-The canonical text lives in **[instructions.md](instructions.md)** at the repo root — visible, reviewable, and copy-ready.
+The canonical text lives in **[instructions.md](instructions.md)** at the repo root. It is visible, reviewable, and copy-ready.
 
 ## Use this file
 


### PR DESCRIPTION
Focuses the README.md primarily on global instructions, and updates the primary curl example to target the global VS Code prompts directory while retaining a note about project-level overrides.