### PR TITLE
feat: suggest refactors

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -56,4 +56,4 @@
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions). NEVER add manual version tracking artifacts.
 
 ### Model Complexity
-- CRITICAL: If task complexity exceeds model capability, warn at response start and end.
+- CRITICAL: Warn at response start and end if task and model are mismatched. Typos don't need frontier models; architecture and multi-repo tasks overwhelm simple ones.

--- a/instructions.md
+++ b/instructions.md
@@ -2,9 +2,9 @@
 
 ### Think & Plan
 - ALWAYS state assumptions, list interpretations, and default to simplicity.
-- ALWAYS evaluate the foundation before acting. You have two paths:
-  1. **Solid Foundation:** Ship the minimal, direct fix immediately. NEVER bundle unrequested refactors.
-  2. **Garbage Foundation:** NEVER duct-tape poorly structured or over-engineered code. STOP and propose a clean refactor.
+- ALWAYS evaluate before acting. You have two paths:
+  1. **Sound code:** Ship the minimal fix. NEVER bundle unrequested refactors.
+  2. **Poorly structured or over-engineered code:** STOP and propose a refactor. Do not refactor without approval.
 
 ### Implementation Discipline
 - NEVER implement unrequested features; limit changes to the active prompt.

--- a/instructions.md
+++ b/instructions.md
@@ -4,7 +4,7 @@
 - ALWAYS state assumptions, list interpretations, and default to simplicity.
 - ALWAYS evaluate before acting. You have two paths:
   1. **Sound code:** Ship the minimal fix. NEVER bundle unrequested refactors.
-  2. **Poorly structured or over-engineered code:** STOP and propose a refactor. Do not refactor without approval.
+  2. **Fragile fix:** If the minimal fix would paper over a design flaw, increase coupling, or duplicate logic — STOP and propose a refactor. Do not refactor without approval.
 
 ### Implementation Discipline
 - NEVER implement unrequested features; limit changes to the active prompt.
@@ -14,15 +14,12 @@
 - DIFF-AS-RECEIPT: Every edit turn MUST include a git diff in a collapsible `<details>` block.
 
 ### Verification
-- ALWAYS define success criteria and verify in terminal (`ls`, `git status`) before marking done.
+- ALWAYS define success criteria and verify in the target runtime (container, browser, build output) before marking done.
 - ALWAYS state a brief plan with verification checks for multi-step tasks.
-- NEVER rely solely on host/local unit tests if a containerized setup (`compose.yml`, `Dockerfile`) is in the workspace; ALWAYS verify changes build and run inside the container.
-- NEVER assume a client-side web application is functional just because the server compiled successfully; ALWAYS verify application bootstrap and check for runtime console exceptions.
 
 ### Dependencies & Solutions
 - ALWAYS avoid dependencies for logic <20 lines. Libraries ONLY for complex/high-risk tasks; verify they are lightweight and maintained.
 - ZERO SPECULATION: Verify APIs via search/run command. NEVER guess. NEVER use abstract/clever solutions unless established.
-- NEVER write speculative code or make blind assumptions about bundler/transpiler interop rules; ALWAYS verify the runtime behavior under the target build context.
 
 ### Fail Fast
 - NEVER write silent fallbacks or rescue scripts. Hard stop (`return`/`throw`/`exit`) with a clear error on failed preconditions.

--- a/instructions.md
+++ b/instructions.md
@@ -3,7 +3,7 @@
 ### Think & Plan
 - ALWAYS state assumptions, list interpretations, and default to simplicity.
 - ALWAYS evaluate before acting. You have two paths:
-  1. **Sound code:** Ship the minimal fix. NEVER bundle unrequested refactors.
+  1. **Clean fix:** Ship the minimal fix. NEVER bundle unrequested refactors.
   2. **Fragile fix:** If the minimal fix would paper over a design flaw, increase coupling, or duplicate logic — STOP and propose a refactor. Do not refactor without approval.
 
 ### Implementation Discipline

--- a/instructions.md
+++ b/instructions.md
@@ -6,7 +6,6 @@
   1. **Solid Foundation:** Ship the minimal, direct fix immediately. NEVER bundle unrequested refactors.
   2. **Garbage Foundation:** NEVER duct-tape poorly structured or over-engineered code. STOP and propose a clean refactor.
 
-
 ### Implementation Discipline
 - NEVER implement unrequested features; limit changes to the active prompt.
 - ALWAYS use direct code (refactor on duplication); touch only logical path files.

--- a/instructions.md
+++ b/instructions.md
@@ -16,10 +16,13 @@
 ### Verification
 - ALWAYS define success criteria and verify in terminal (`ls`, `git status`) before marking done.
 - ALWAYS state a brief plan with verification checks for multi-step tasks.
+- NEVER rely solely on host/local unit tests if a containerized setup (`compose.yml`, `Dockerfile`) is in the workspace; ALWAYS verify changes build and run inside the container.
+- NEVER assume a client-side web application is functional just because the server compiled successfully; ALWAYS verify application bootstrap and check for runtime console exceptions.
 
 ### Dependencies & Solutions
 - ALWAYS avoid dependencies for logic <20 lines. Libraries ONLY for complex/high-risk tasks; verify they are lightweight and maintained.
 - ZERO SPECULATION: Verify APIs via search/run command. NEVER guess. NEVER use abstract/clever solutions unless established.
+- NEVER write speculative code or make blind assumptions about bundler/transpiler interop rules; ALWAYS verify the runtime behavior under the target build context.
 
 ### Fail Fast
 - NEVER write silent fallbacks or rescue scripts. Hard stop (`return`/`throw`/`exit`) with a clear error on failed preconditions.

--- a/instructions.md
+++ b/instructions.md
@@ -2,8 +2,10 @@
 
 ### Think & Plan
 - ALWAYS state assumptions, list interpretations, and default to simplicity.
-- ALWAYS fix FIRST; ask before proposing broader refactors or enhancements.
-- NEVER patch symptoms on poorly structured or over-engineered components; immediately propose a clean refactor instead.
+- ALWAYS evaluate the foundation before acting. You have two paths:
+  1. **Solid Foundation:** Ship the minimal, direct fix immediately. NEVER bundle unrequested refactors.
+  2. **Garbage Foundation:** NEVER duct-tape poorly structured or over-engineered code. STOP and propose a clean refactor.
+
 
 ### Implementation Discipline
 - NEVER implement unrequested features; limit changes to the active prompt.

--- a/instructions.md
+++ b/instructions.md
@@ -56,9 +56,4 @@
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions). NEVER add manual version tracking artifacts.
 
 ### Model Complexity
-
-CRITICAL: Match model tier to task complexity. If mismatched, warn and recommend the correct tier at response start and end.
-
-- **T1 (Trivial)**: Typos, formatting, basic scripts.
-- **T2 (Standard)**: Features, refactors, tests.
-- **T3 (Architecture)**: System design, multi-repo.
+- CRITICAL: If task complexity exceeds model capability, warn at response start and end.

--- a/instructions.md
+++ b/instructions.md
@@ -3,6 +3,7 @@
 ### Think & Plan
 - ALWAYS state assumptions, list interpretations, and default to simplicity.
 - ALWAYS fix FIRST; ask before proposing broader refactors or enhancements.
+- NEVER patch symptoms on poorly structured or over-engineered components; immediately propose a clean refactor instead.
 
 ### Implementation Discipline
 - NEVER implement unrequested features; limit changes to the active prompt.


### PR DESCRIPTION
## Summary

Sharpens the refactor-proposal trigger, condenses verbose verification rules, and tightens the model complexity section.

### Changes

1. **Refactor trigger** — Replaces subjective code-quality label with consequence-based trigger. Agent evaluates whether its own fix would be duct tape (paper over a design flaw, increase coupling, or duplicate logic) rather than judging the codebase as "good" or "bad." Decision paths are parallel: **Clean fix** → ship it, **Fragile fix** → propose refactor.

2. **Verification** — Collapses three verbose runtime-verification lines (~400 chars) into one: verify in the target runtime (container, browser, build output). Repo-state verification is already covered by DIFF-AS-RECEIPT and the "committed, pushed, and PR created" operational guardrail.

3. **Model Complexity** — Drops T1/T2/T3 tier taxonomy (models cannot self-classify into arbitrary tiers). Reframes as capability self-assessment, which models can actually perform.

### Character Budget

| State | Bytes | Headroom |
|-------|-------|----------|
| Before PR (main) | 3830 | 170 |
| Original PR draft | 4075 | **-75 (over cap)** |
| Current | 3368 | **632** |