### PR TITLE
docs: restore explicit model complexity guidelines, anti-sycophancy

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -57,9 +57,8 @@
 
 ### Model Complexity
 
-CRITICAL: Match model tier to task complexity. If mismatched, warn and recommend the correct tier at response start and end.
+CRITICAL: If the active model tier and task tier are mismatched, warn at response start and end. The warning MUST state: (1) the task tier, (2) the active model tier, and (3) whether to UPSCALE or DOWNSCALE.
 
-- **T1 (Trivial)**: Typos, formatting, basic scripts. (Warn to DOWNSCALE if T2/T3 active)
-- **T2 (Standard)**: Features, refactors, tests. (Warn to UPSCALE if T1; DOWNSCALE if T3)
-- **T3 (Architecture)**: System design, multi-repo. (Warn to UPSCALE if T1/T2 active)
-
+- **T1 (Trivial)**: Typos, formatting, basic scripts → lightweight models sufficient
+- **T2 (Standard)**: Features, refactors, tests → mid-tier models
+- **T3 (Architecture)**: System design, concurrency, multi-repo → frontier models required

--- a/instructions.md
+++ b/instructions.md
@@ -6,6 +6,7 @@
   1. **Clean fix:** Ship the minimal fix. NEVER bundle unrequested refactors.
   2. **Fragile fix:** If the minimal fix would paper over a design flaw, increase coupling, or duplicate logic — STOP and propose a refactor. Do not refactor without approval.
 - Defend technical positions with evidence. Do not change recommendations solely because the user disagrees — require new information or a flaw in reasoning.
+- If a request presupposes a bad practice, challenge the premise rather than answering as asked.
 
 ### Implementation Discipline
 - NEVER implement unrequested features; limit changes to the active prompt.

--- a/instructions.md
+++ b/instructions.md
@@ -56,4 +56,4 @@
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions). NEVER add manual version tracking artifacts.
 
 ### Model Complexity
-- If you're not the right fit for this task, say so at response start and end with a brief reason. Otherwise, no comment.
+- If this task exceeds your capabilities, warn at response start and end to UPSCALE with a brief reason. If this task is trivial relative to your capabilities, warn to DOWNSCALE. Otherwise, no comment.

--- a/instructions.md
+++ b/instructions.md
@@ -56,4 +56,4 @@
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions). NEVER add manual version tracking artifacts.
 
 ### Model Complexity
-- If this task exceeds your capabilities (e.g., complex architecture, multi-repo, concurrency), warn at response start and end to UPSCALE with a brief reason. If this task is trivial relative to your capabilities (e.g., typos, formatting), warn to DOWNSCALE. Otherwise, no comment.
+- If this task exceeds your capabilities, warn at response start and end to UPSCALE with a brief reason. If this task is trivial relative to your capabilities, warn to DOWNSCALE. Otherwise, no comment.

--- a/instructions.md
+++ b/instructions.md
@@ -5,6 +5,7 @@
 - ALWAYS evaluate before acting. You have two paths:
   1. **Clean fix:** Ship the minimal fix. NEVER bundle unrequested refactors.
   2. **Fragile fix:** If the minimal fix would paper over a design flaw, increase coupling, or duplicate logic — STOP and propose a refactor. Do not refactor without approval.
+- Defend technical positions with evidence. Do not change recommendations solely because the user disagrees — require new information or a flaw in reasoning.
 
 ### Implementation Discipline
 - NEVER implement unrequested features; limit changes to the active prompt.

--- a/instructions.md
+++ b/instructions.md
@@ -56,9 +56,4 @@
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions). NEVER add manual version tracking artifacts.
 
 ### Model Complexity
-
-CRITICAL: If the active model tier and task tier are mismatched, warn at response start and end. The warning MUST state: (1) the task tier, (2) the active model tier, and (3) whether to UPSCALE or DOWNSCALE. If matched, no warning.
-
-- **T1 (Trivial)**: Typos, formatting, basic scripts → lightweight models sufficient
-- **T2 (Standard)**: Features, refactors, tests → mid-tier models
-- **T3 (Architecture)**: System design, concurrency, multi-repo → frontier models required
+- If this task exceeds your capabilities (e.g., complex architecture, multi-repo, concurrency), warn at response start and end to UPSCALE with a brief reason. If this task is trivial relative to your capabilities (e.g., typos, formatting), warn to DOWNSCALE. Otherwise, no comment.

--- a/instructions.md
+++ b/instructions.md
@@ -56,4 +56,4 @@
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions). NEVER add manual version tracking artifacts.
 
 ### Model Complexity
-- If this task exceeds your capabilities, warn at response start and end to UPSCALE with a brief reason. If this task is trivial relative to your capabilities, warn to DOWNSCALE. Otherwise, no comment.
+- If you're not the right fit for this task, say so at response start and end with a brief reason. Otherwise, no comment.

--- a/instructions.md
+++ b/instructions.md
@@ -56,4 +56,10 @@
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions). NEVER add manual version tracking artifacts.
 
 ### Model Complexity
-- CRITICAL: Warn at response start and end if task and model are mismatched. Typos don't need frontier models; architecture and multi-repo tasks overwhelm simple ones.
+
+CRITICAL: Match model tier to task complexity. If mismatched, warn and recommend the correct tier at response start and end.
+
+- **T1 (Trivial)**: Typos, formatting, basic scripts. (Warn to DOWNSCALE if T2/T3 active)
+- **T2 (Standard)**: Features, refactors, tests. (Warn to UPSCALE if T1; DOWNSCALE if T3)
+- **T3 (Architecture)**: System design, multi-repo. (Warn to UPSCALE if T1/T2 active)
+

--- a/instructions.md
+++ b/instructions.md
@@ -57,7 +57,7 @@
 
 ### Model Complexity
 
-CRITICAL: If the active model tier and task tier are mismatched, warn at response start and end. The warning MUST state: (1) the task tier, (2) the active model tier, and (3) whether to UPSCALE or DOWNSCALE.
+CRITICAL: If the active model tier and task tier are mismatched, warn at response start and end. The warning MUST state: (1) the task tier, (2) the active model tier, and (3) whether to UPSCALE or DOWNSCALE. If matched, no warning.
 
 - **T1 (Trivial)**: Typos, formatting, basic scripts → lightweight models sufficient
 - **T2 (Standard)**: Features, refactors, tests → mid-tier models

--- a/instructions.md
+++ b/instructions.md
@@ -56,4 +56,4 @@
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions). NEVER add manual version tracking artifacts.
 
 ### Model Complexity
-- If this task exceeds your capabilities, warn at response start and end to UPSCALE with a brief reason. If this task is trivial relative to your capabilities, warn to DOWNSCALE. Otherwise, no comment.
+- If this task exceeds your capabilities, warn at response start and end to UPSCALE with a brief reason. If this task is trivial relative to your capabilities, warn at response start and end to DOWNSCALE. Otherwise, no comment.


### PR DESCRIPTION
## Problem

The model complexity instruction was compressed across #158 and #161 until it lost all actionable structure. The final single-bullet version produced vague warnings like:

> ⚠️ This task has been completed using the lightweight Gemini 3.5 Flash model.

This tells the user nothing — no task classification, no recommended action, no reason.

## Changes

### Model Complexity (rewrite)

Replaced the compressed single-bullet with two concrete self-assessments:

- **Exceeds capabilities** → warn to UPSCALE at response start and end with a reason
- **Trivial relative to capabilities** → warn to DOWNSCALE at response start and end
- **Good fit** → no comment (explicitly silenced)

Dropped the T1/T2/T3 tier taxonomy entirely — models self-assess better with concrete questions ('does this exceed my capabilities?') than by classifying tasks into an arbitrary taxonomy.

### Anti-sycophancy (new)

Added two rules under Think & Plan:

1. **Defend positions with evidence** — do not change recommendations solely because the user disagrees. Require new information or a demonstrated flaw in reasoning.
2. **Challenge flawed premises** — if a request presupposes a bad practice, challenge the premise rather than answering as asked.

These are deliberately tone-neutral (no personality, no snark) so they work org-wide. Personal tone preferences layer on top via individual developer configs.

## Character budget

3,760 / 4,000 (240 remaining)