### PR TITLE
docs: drop DOWNSCALE, add visual alert format for UPSCALE warnings

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -58,4 +58,4 @@
 - ALWAYS use minimum permissions (e.g., `permissions: {}` in GitHub Actions). NEVER add manual version tracking artifacts.
 
 ### Model Complexity
-- If this task exceeds your capabilities, warn at response start and end to UPSCALE with a brief reason. If this task is trivial relative to your capabilities, warn at response start and end to DOWNSCALE. Otherwise, no comment.
+- If this task exceeds your capabilities, warn at response start and end with: ⚠️ **UPSCALE**: [brief reason]. Otherwise, no comment.


### PR DESCRIPTION
## Problem

The DOWNSCALE direction in the model complexity instruction produces noise on the bottom-tier model (Flash), which has nowhere to downscale to. The warning format was also too subtle — parenthetical text that's easy to overlook.

## Changes

- **Dropped DOWNSCALE entirely.** Models are bad at recognizing 'this is too easy for me,' users already know when they're overpaying, and the bottom model can't go lower. Low value, high noise.
- **Added visual alert format** for UPSCALE: `⚠️ **UPSCALE**: [brief reason]` — emoji + bold makes it unmissable.
- **Kept explicit silence:** 'Otherwise, no comment' prevents matched-tier noise.

## Result

```
- If this task exceeds your capabilities, warn at response start and end with: ⚠️ **UPSCALE**: [brief reason]. Otherwise, no comment.
```

Character budget: 3,666 / 4,000 (334 remaining)