### PR TITLE
docs: add scope negotiation rule

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -7,6 +7,7 @@
   2. **Fragile fix:** If the minimal fix would paper over a design flaw, increase coupling, or duplicate logic — STOP and propose a refactor. Do not refactor without approval.
 - Defend technical positions with evidence. Do not change recommendations solely because the user disagrees — require new information or a flaw in reasoning.
 - If a request presupposes a bad practice, challenge the premise rather than answering as asked.
+- If scope or intent is ambiguous, DO NOT guess. Ask one clarifying question with bulleted options.
 
 ### Implementation Discipline
 - NEVER implement unrequested features; limit changes to the active prompt.
@@ -27,6 +28,7 @@ NEVER mark work complete until you have:
 
 ### Fail Fast
 - NEVER write silent fallbacks or rescue scripts. Hard stop (`return`/`throw`/`exit`) with a clear error on failed preconditions.
+- When reporting errors, summarize the root cause and provide the relevant stack trace snippet. Do not dump the entire raw log.
 
 ## Standards
 

--- a/instructions.md
+++ b/instructions.md
@@ -28,7 +28,6 @@ NEVER mark work complete until you have:
 
 ### Fail Fast
 - NEVER write silent fallbacks or rescue scripts. Hard stop (`return`/`throw`/`exit`) with a clear error on failed preconditions.
-- When reporting errors, summarize the root cause and provide the relevant stack trace snippet. Do not dump the entire raw log.
 
 ## Standards
 


### PR DESCRIPTION
## Problem

The org-wide instructions lack guidance on what to do when a prompt is ambiguous or underspecified. This leads to agents guessing intent and producing unrequested or incorrect code, violating the 'ZERO SPECULATION' mandate.

## Changes

- **Added Scope Negotiation (Think & Plan):** Instructs the agent to explicitly stop and ask one clarifying question with bulleted options when scope or intent is ambiguous. This provides a deterministic escape hatch that prevents hallucinated requirements.

*(Note: An error communication rule was drafted but dropped from this PR to prevent instruction overload/attention dilution, as excessive stack trace dumping is not currently a systemic issue with premier models).*

Character budget: 3,689 / 4,000 (311 remaining)