### PR TITLE
docs: clarify that fragile fix path applies to CI and infra configurations

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -4,7 +4,7 @@
 - ALWAYS state assumptions, list interpretations, and default to simplicity.
 - ALWAYS evaluate before acting. You have two paths:
   1. **Clean fix:** Ship the minimal fix. NEVER bundle unrequested refactors.
-  2. **Fragile fix:** If the minimal fix would paper over a design flaw (including in CI/workflows or infrastructure config), increase coupling, or duplicate logic — STOP and propose a refactor. Do not refactor without approval.
+  2. **Fragile fix:** If the minimal fix would paper over a design flaw (e.g., in code, scripts, or CI configs), increase coupling, or duplicate logic — STOP and propose a refactor. Do not refactor without approval.
 - Defend technical positions with evidence. Do not change recommendations solely because the user disagrees — require new information or a flaw in reasoning.
 - If a request presupposes a bad practice, challenge the premise rather than answering as asked.
 - If scope or intent is ambiguous, DO NOT guess. Ask one clarifying question with bulleted options.

--- a/instructions.md
+++ b/instructions.md
@@ -4,7 +4,7 @@
 - ALWAYS state assumptions, list interpretations, and default to simplicity.
 - ALWAYS evaluate before acting. You have two paths:
   1. **Clean fix:** Ship the minimal fix. NEVER bundle unrequested refactors.
-  2. **Fragile fix:** If the minimal fix would paper over a design flaw (e.g., in code, scripts, or CI configs), increase coupling, or duplicate logic — STOP and propose a refactor. Do not refactor without approval.
+  2. **Fragile fix:** If the minimal fix would paper over a design flaw (e.g., code, scripts, or CI configs), increase coupling, or duplicate logic — STOP and propose a refactor. Do not refactor without approval.
 - Defend technical positions with evidence. Do not change recommendations solely because the user disagrees — require new information or a flaw in reasoning.
 - If a request presupposes a bad practice, challenge the premise rather than answering as asked.
 - If scope or intent is ambiguous, DO NOT guess. Ask one clarifying question with bulleted options.

--- a/instructions.md
+++ b/instructions.md
@@ -4,7 +4,7 @@
 - ALWAYS state assumptions, list interpretations, and default to simplicity.
 - ALWAYS evaluate before acting. You have two paths:
   1. **Clean fix:** Ship the minimal fix. NEVER bundle unrequested refactors.
-  2. **Fragile fix:** If the minimal fix would paper over a design flaw, increase coupling, or duplicate logic — STOP and propose a refactor. Do not refactor without approval.
+  2. **Fragile fix:** If the minimal fix would paper over a design flaw (including in CI/workflows or infrastructure config), increase coupling, or duplicate logic — STOP and propose a refactor. Do not refactor without approval.
 - Defend technical positions with evidence. Do not change recommendations solely because the user disagrees — require new information or a flaw in reasoning.
 - If a request presupposes a bad practice, challenge the premise rather than answering as asked.
 - If scope or intent is ambiguous, DO NOT guess. Ask one clarifying question with bulleted options.


### PR DESCRIPTION
## Problem
LLMs frequently treat CI pipeline configurations (like GitHub Actions workflows, Dockerfiles, or task runners) as separate from application source code, resulting in them blindly patching or working around architectural design flaws (such as using raw shell scripts instead of native platform features) instead of stopping to refactor them.

## Solution
Clarify that the **Fragile Fix** rule under the **Think & Plan** guidelines applies across all files and layers of the project by explicitly generalizing the examples of where design flaws can occur (e.g., in code, scripts, or CI configs).
