### PR TITLE
docs: add dormant project status notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > 
 > The Copilot guidelines in [instructions.md](instructions.md) are complete and can be used immediately in your local setup or individual repositories.
 > 
-> We are looking for someone to champion these instructions for org-wide adoption across the `bcgov` GitHub organization. If you have the interest and influence to push this forward with platform administrators, please take this work and run with it.
+> We are looking for someone to champion these instructions for org-wide adoption across the `bcgov` GitHub organization. If you have the interest and influence to push this forward with platform administrators, please open an issue or discussion in this repository to coordinate.
 
 Guidelines for AI-assisted development, written with the intent of becoming a practical standard for teams across the Government of British Columbia.
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 > [!NOTE]
 > **Project Status: Dormant**
 > 
-> The instructions in [instructions.md](instructions.md) are complete and available for individual developer or project-level use. Active updates are currently paused pending org-level adoption as default Copilot instructions in `bcgov`.
+> The instructions in [instructions.md](instructions.md) are complete, fully tested, and ready for use. Active maintenance is paused pending org-level adoption by `bcgov` platform admins.
 > 
-> If you are interested in adopting this for your team or pushing for org-level enablement, feel free to open an issue or pull request.
+> No code changes or pull requests are needed. If an org platform admin wants to enable these default instructions for `bcgov`, copy [instructions.md](instructions.md) directly into your organization's Copilot settings.
 
 Guidelines for AI-assisted development, written with the intent of becoming a practical standard for teams across the Government of British Columbia.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Agent Instructions
 
+> [!NOTE]
+> **Project Status: Dormant**
+> 
+> The instructions in [instructions.md](instructions.md) are complete and available for individual developer or project-level use. Active updates are currently paused pending org-level adoption as default Copilot instructions in `bcgov`.
+> 
+> If you are interested in adopting this for your team or pushing for org-level enablement, feel free to open an issue or pull request.
+
 Guidelines for AI-assisted development, written with the intent of becoming a practical standard for teams across the Government of British Columbia.
 
 > **Not an official BC Government publication.** Content here reflects community work in progress. It does not speak for, bind, or represent the Province of British Columbia. We welcome contributors so this can grow into something genuinely useful for public-sector developers in BC.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Guidelines for AI-assisted development, written with the intent of becoming a practical standard for teams across the Government of British Columbia.
 
-> **Not an official BC Government publication.** Content here reflects community work in progress. It does not speak for, bind, or represent the Province of British Columbia. We welcome contributors so this can grow into something genuinely useful for public-sector developers in BC.
+> **Not an official BC Government publication.** This repository does not speak for, bind, or represent the Province of British Columbia.
 
 The canonical text lives in **[instructions.md](instructions.md)** at the repo root.
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 > [!NOTE]
 > **Project Status: Dormant**
 > 
-> The instructions in [instructions.md](instructions.md) are complete, fully tested, and ready for use. Active maintenance is paused pending org-level adoption by `bcgov` platform admins.
+> The Copilot guidelines in [instructions.md](instructions.md) are complete and can be used immediately in your local setup or individual repositories.
 > 
-> No code changes or pull requests are needed. If an org platform admin wants to enable these default instructions for `bcgov`, copy [instructions.md](instructions.md) directly into your organization's Copilot settings.
+> We are looking for someone to champion these instructions for org-wide adoption across the `bcgov` GitHub organization. If you have the interest and influence to push this forward with platform administrators, please take this work and run with it.
 
 Guidelines for AI-assisted development, written with the intent of becoming a practical standard for teams across the Government of British Columbia.
 


### PR DESCRIPTION
Adds a Dormant project status callout banner to README.md to reflect that active updates are paused pending org-level adoption.